### PR TITLE
apply vm patch.

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -845,7 +845,7 @@ class Blocks {
     getAllVariableAndListReferences (optBlocks, optIncludeBroadcast) {
         const blocks = optBlocks ? optBlocks : this._blocks;
         const allReferences = Object.create(null);
-        for (const blockId in blocks) {
+        for (const blockId of Object.keys(blocks)) {
             let varOrListField = null;
             let varType = null;
             if (blocks[blockId].fields.VARIABLE) {

--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -747,8 +747,7 @@ class Target extends EventEmitter {
         }
         // Rename any local variables that were missed above because they aren't
         // referenced by any blocks
-        for (const id in unreferencedLocalVarIds) {
-            const varId = unreferencedLocalVarIds[id];
+        for (const varId of unreferencedLocalVarIds) {
             const name = this.variables[varId].name;
             const type = this.variables[varId].type;
             renameConflictingLocalVar(varId, name, type);


### PR DESCRIPTION
### Resolves

The "for in loop" for Array includes extra object property that add by Opal.
So do not use the "for in loop" for Array.

### Proposed Changes

The "for in loop" changes the "for of loop".

### Reason for Changes

See above Resolves section.

### Test Coverage

no.
