### PR TITLE
suppress warning when enabled extension.

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1121,7 +1121,7 @@ class VirtualMachine extends EventEmitter {
      */
     setLocale (locale, messages) {
         if (locale !== formatMessage.setup().locale) {
-            formatMessage.setup({locale: locale, translations: {[locale]: messages}});
+            formatMessage.setup({locale: locale, translations: {[locale]: Object.assign({}, messages)}});
         }
         return this.extensionManager.refreshBlocks();
     }


### PR DESCRIPTION
### Resolves

You will get below warning message when you have enabled the extension that use formatMessage function. 

```
Warning: Failed prop type: Invalid prop `messages.makeymakey.downArrow` of type `object` supplied to `Blocks`, expected `string`.
    in Blocks (created by Connect(Blocks))
    in Connect(Blocks) (created by ErrorBoundaryWrapper)
    in ErrorBoundary (created by Connect(ErrorBoundary))
    in Connect(ErrorBoundary) (created by ErrorBoundaryWrapper)
    in ErrorBoundaryWrapper (created by MediaQuery)
    in div (created by Box)
    in Box (created by MediaQuery)
    in div (created by TabPanel)
    in TabPanel (created by MediaQuery)
    in div (created by UncontrolledTabs)
    in UncontrolledTabs (created by Tabs)
    in Tabs (created by MediaQuery)
    in div (created by Box)
    in Box (created by MediaQuery)
    in div (created by Box)
    in Box (created by MediaQuery)
    in div (created by Box)
    in Box (created by MediaQuery)
    in div (created by Box)
    in Box (created by MediaQuery)
    in MediaQuery (created by GUIComponent)
    in GUIComponent (created by Connect(GUIComponent))
    in Connect(GUIComponent) (created by InjectIntl(Connect(GUIComponent)))
    in InjectIntl(Connect(GUIComponent)) (created by GUI)
    in GUI (created by Connect(GUI))
    in Connect(GUI) (created by InjectIntl(Connect(GUI)))
    in InjectIntl(Connect(GUI)) (created by CloudManager)
    in CloudManager (created by Connect(CloudManager))
    in Connect(CloudManager) (created by VMManager)
    in VMManager (created by Connect(VMManager))
    in Connect(VMManager) (created by VMListener)
    in VMListener (created by Connect(VMListener))
    in Connect(VMListener) (created by ProjectSaverComponent)
    in ProjectSaverComponent (created by Connect(ProjectSaverComponent))
    in Connect(ProjectSaverComponent) (created by TitledComponent)
    in TitledComponent (created by Connect(TitledComponent))
    in Connect(TitledComponent) (created by InjectIntl(Connect(TitledComponent)))
    in InjectIntl(Connect(TitledComponent)) (created by ProjectFetcherComponent)
    in ProjectFetcherComponent (created by Connect(ProjectFetcherComponent))
    in Connect(ProjectFetcherComponent) (created by InjectIntl(Connect(ProjectFetcherComponent)))
    in InjectIntl(Connect(ProjectFetcherComponent)) (created by QueryParserComponent)
    in QueryParserComponent (created by Connect(QueryParserComponent))
    in Connect(QueryParserComponent) (created by FontLoaderComponent)
    in FontLoaderComponent (created by Connect(FontLoaderComponent))
    in Connect(FontLoaderComponent) (created by ErrorBoundaryWrapper)
    in ErrorBoundary (created by Connect(ErrorBoundary))
    in Connect(ErrorBoundary) (created by ErrorBoundaryWrapper)
    in ErrorBoundaryWrapper (created by LocalizationWrapper)
    in IntlProvider (created by Connect(IntlProvider))
    in Connect(IntlProvider) (created by LocalizationWrapper)
    in LocalizationWrapper (created by Connect(LocalizationWrapper))
    in Connect(LocalizationWrapper) (created by HashParserComponent)
    in HashParserComponent (created by Connect(HashParserComponent))
    in Connect(HashParserComponent) (created by AppStateWrapper)
    in IntlProvider (created by Connect(IntlProvider))
    in Connect(IntlProvider) (created by AppStateWrapper)
    in Provider (created by AppStateWrapper)
    in AppStateWrapper
r @ react_devtools_backend.js:6
printWarning @ checkPropTypes.js:20
checkPropTypes @ checkPropTypes.js:82
validatePropTypes @ react.development.js:1171
createElementWithValidation @ react.development.js:1268
render @ connectAdvanced.js:243
finishClassComponent @ react-dom.development.js:7873
updateClassComponent @ react-dom.development.js:7850
beginWork @ react-dom.development.js:8225
performUnitOfWork @ react-dom.development.js:10224
workLoop @ react-dom.development.js:10288
callCallback @ react-dom.development.js:542
invokeGuardedCallbackDev @ react-dom.development.js:581
invokeGuardedCallback @ react-dom.development.js:438
renderRoot @ react-dom.development.js:10366
performWorkOnRoot @ react-dom.development.js:11014
performWork @ react-dom.development.js:10967
batchedUpdates @ react-dom.development.js:11086
batchedUpdates @ react-dom.development.js:2330
dispatchEvent @ react-dom.development.js:3421
```

The reason for this is the formatMesage method used in the extension. The formatMessage changes message catalog from scratch-gui. So I changed that it clone when set.

### Proposed Changes

above.

### Reason for Changes

above.

### Test Coverage

no.
