### PR TITLE
Fix smalrubot S1 sensor labels: Unify to sensorPositionsMenu namespace

### DIFF
--- a/src/extensions/scratch3_smalrubot_s1/index.js
+++ b/src/extensions/scratch3_smalrubot_s1/index.js
@@ -894,41 +894,41 @@ class Scratch3SmalrubotS1Blocks {
         return [
             {
                 text: formatMessage({
-                    id: 'smalrubotS1.positionsMenu.left',
-                    default: 'left',
-                    description: 'label for "left" element in position picker for Smalrubot S1 extension'
+                    id: 'smalrubotS1.sensorPositionsMenu.left',
+                    default: 'left(A4)',
+                    description: 'label for "left" sensor in position picker for Smalrubot S1 extension'
                 }),
                 value: 'left'
             },
             {
                 text: formatMessage({
-                    id: 'smalrubotS1.positionsMenu.right',
-                    default: 'right',
-                    description: 'label for "right" element in position picker for Smalrubot S1 extension'
+                    id: 'smalrubotS1.sensorPositionsMenu.right',
+                    default: 'right(A5)',
+                    description: 'label for "right" sensor in position picker for Smalrubot S1 extension'
                 }),
                 value: 'right'
             },
             {
                 text: formatMessage({
-                    id: 'smalrubotS1.positionsMenu.touch',
-                    default: 'touch',
-                    description: 'label for "touch" element in position picker for Smalrubot S1 extension'
+                    id: 'smalrubotS1.sensorPositionsMenu.touch',
+                    default: 'touch(A2)',
+                    description: 'label for "touch" sensor in position picker for Smalrubot S1 extension'
                 }),
                 value: 'touch'
             },
             {
                 text: formatMessage({
-                    id: 'smalrubotS1.positionsMenu.light',
-                    default: 'light',
-                    description: 'label for "light" element in position picker for Smalrubot S1 extension'
+                    id: 'smalrubotS1.sensorPositionsMenu.light',
+                    default: 'light(A6)',
+                    description: 'label for "light" sensor in position picker for Smalrubot S1 extension'
                 }),
                 value: 'light'
             },
             {
                 text: formatMessage({
-                    id: 'smalrubotS1.positionsMenu.sound',
-                    default: 'sound',
-                    description: 'label for "sound" element in position picker for Smalrubot S1 extension'
+                    id: 'smalrubotS1.sensorPositionsMenu.sound',
+                    default: 'sound(A7)',
+                    description: 'label for "sound" sensor in position picker for Smalrubot S1 extension'
                 }),
                 value: 'sound'
             }


### PR DESCRIPTION
## Summary

センサーラベルを統一した名前空間に移行し、保守性を向上させます。

Unify sensor labels to a consistent namespace to improve maintainability.

## Changes Made

### sensor labels namespace unification
- **All sensor labels** now use `smalrubotS1.sensorPositionsMenu.*` namespace:
  - `smalrubotS1.sensorPositionsMenu.left` (A4)
  - `smalrubotS1.sensorPositionsMenu.right` (A5) 
  - `smalrubotS1.sensorPositionsMenu.touch` (A2)
  - `smalrubotS1.sensorPositionsMenu.light` (A6)
  - `smalrubotS1.sensorPositionsMenu.sound` (A7)

### Default values enhanced
- Port numbers are now included in default values for clarity
- Users can easily identify hardware port connections

### Code organization
- Clearer separation between sensor and motor/LED labels
- Consistent naming pattern for all sensor-related translations

## Technical Details

**File Changed:**
- `src/extensions/scratch3_smalrubot_s1/index.js`: Updated `SENSOR_POSITIONS_MENU` message IDs

**Impact:**
- Requires corresponding localization updates in smalruby3-gui
- Improves maintainability for future sensor additions
- Better user experience with clear hardware mapping

## Testing

- ✅ Lint passed
- ✅ All tests passed
- ✅ No breaking changes to existing functionality

## Related

- Addresses: smalruby/smalruby3-gui#405
- Companion PR needed: smalruby3-gui localization updates

🤖 Generated with [Claude Code](https://claude.ai/code)