### PR TITLE
fix(meshV2): resolve GraphQL coerced Null value error and fix domain initialization

### DIFF
--- a/src/extensions/scratch3_mesh_v2/gql-operations.js
+++ b/src/extensions/scratch3_mesh_v2/gql-operations.js
@@ -2,7 +2,7 @@ const gqlTag = require('graphql-tag');
 const gql = gqlTag.default || gqlTag;
 
 const LIST_GROUPS_BY_DOMAIN = gql`
-  query ListGroupsByDomain($domain: String) {
+  query ListGroupsByDomain($domain: String!) {
     listGroupsByDomain(domain: $domain) {
       id
       domain
@@ -14,8 +14,14 @@ const LIST_GROUPS_BY_DOMAIN = gql`
   }
 `;
 
+const CREATE_DOMAIN = gql`
+  mutation CreateDomain {
+    createDomain
+  }
+`;
+
 const CREATE_GROUP = gql`
-  mutation CreateGroup($name: String!, $hostId: ID!, $domain: String) {
+  mutation CreateGroup($name: String!, $hostId: ID!, $domain: String!) {
     createGroup(name: $name, hostId: $hostId, domain: $domain) {
       id
       domain
@@ -127,6 +133,7 @@ const ON_GROUP_DISSOLVE = gql`
 
 module.exports = {
     LIST_GROUPS_BY_DOMAIN,
+    CREATE_DOMAIN,
     CREATE_GROUP,
     JOIN_GROUP,
     LEAVE_GROUP,

--- a/src/extensions/scratch3_mesh_v2/gql-operations.js
+++ b/src/extensions/scratch3_mesh_v2/gql-operations.js
@@ -2,7 +2,7 @@ const gqlTag = require('graphql-tag');
 const gql = gqlTag.default || gqlTag;
 
 const LIST_GROUPS_BY_DOMAIN = gql`
-  query ListGroupsByDomain($domain: String!) {
+  query ListGroupsByDomain($domain: String) {
     listGroupsByDomain(domain: $domain) {
       id
       domain
@@ -15,7 +15,7 @@ const LIST_GROUPS_BY_DOMAIN = gql`
 `;
 
 const CREATE_GROUP = gql`
-  mutation CreateGroup($name: String!, $hostId: ID!, $domain: String!) {
+  mutation CreateGroup($name: String!, $hostId: ID!, $domain: String) {
     createGroup(name: $name, hostId: $hostId, domain: $domain) {
       id
       domain

--- a/src/extensions/scratch3_mesh_v2/index.js
+++ b/src/extensions/scratch3_mesh_v2/index.js
@@ -213,18 +213,19 @@ class Scratch3MeshV2Blocks {
     /* istanbul ignore next */
     connectedMessage () {
         if (this.meshService && this.meshService.groupId) {
+            const meshIdWithDomain = `${this.meshService.groupId}@${this.meshService.domain}`;
             if (this.meshService.isHost) {
                 return formatMessage({
                     id: 'mesh.registeredHostV2',
                     default: 'Registered Host Mesh V2 [{ MESH_ID }]',
                     description: 'label for registered Host Mesh in connect modal for Mesh V2 extension'
-                }, {MESH_ID: this.meshService.groupId});
+                }, {MESH_ID: meshIdWithDomain});
             }
             return formatMessage({
                 id: 'mesh.joinedMeshV2',
                 default: 'Joined Mesh V2 [{ MESH_ID }]',
                 description: 'label for joined Mesh in connect modal for Mesh V2 extension'
-            }, {MESH_ID: this.meshService.groupId});
+            }, {MESH_ID: meshIdWithDomain});
         }
         return formatMessage({
             id: 'mesh.notConnectedV2',

--- a/src/extensions/scratch3_mesh_v2/index.js
+++ b/src/extensions/scratch3_mesh_v2/index.js
@@ -137,6 +137,7 @@ class Scratch3MeshV2Blocks {
     scan () {
         if (!this.meshService) return;
         this.meshService.listGroups().then(groups => {
+            this.discoveredGroups = groups;
             const peripherals = groups.map(group => ({
                 peripheralId: group.id,
                 name: formatMessage({
@@ -184,7 +185,9 @@ class Scratch3MeshV2Blocks {
                     this.runtime.emit(this.runtime.constructor.PERIPHERAL_CONNECTION_ERROR_ID, id);
                 });
         } else {
-            this.meshService.joinGroup(id).then(() => {
+            const group = this.discoveredGroups && this.discoveredGroups.find(g => g.id === id);
+            const domain = group ? group.domain : null;
+            this.meshService.joinGroup(id, domain).then(() => {
                 this.runtime.emit(this.runtime.constructor.PERIPHERAL_CONNECTED);
             })
                 /* istanbul ignore next */

--- a/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -58,12 +58,13 @@ class MeshV2Service {
             const group = result.data.createGroup;
             this.groupId = group.id;
             this.groupName = group.name;
+            this.domain = group.domain; // Update domain from server
             this.isHost = true;
 
             this.startSubscriptions();
             this.startConnectionTimer();
             
-            log.info(`Mesh V2: Created group ${this.groupName} (${this.groupId})`);
+            log.info(`Mesh V2: Created group ${this.groupName} (${this.groupId}) in domain ${this.domain}`);
             return group;
         } catch (error) {
             log.error(`Mesh V2: Failed to create group: ${error}`);
@@ -90,7 +91,7 @@ class MeshV2Service {
         }
     }
 
-    async joinGroup (groupId) {
+    async joinGroup (groupId, domain) {
         if (!this.client) throw new Error('Client not initialized');
 
         try {
@@ -98,19 +99,20 @@ class MeshV2Service {
                 mutation: JOIN_GROUP,
                 variables: {
                     groupId: groupId,
-                    domain: this.domain,
+                    domain: domain || this.domain,
                     nodeId: this.meshId
                 }
             });
 
             const node = result.data.joinGroup;
             this.groupId = groupId;
+            this.domain = node.domain; // Update domain from server
             this.isHost = false;
 
             this.startSubscriptions();
             this.startConnectionTimer();
 
-            log.info(`Mesh V2: Joined group ${this.groupId}`);
+            log.info(`Mesh V2: Joined group ${this.groupId} in domain ${this.domain}`);
             return node;
         } catch (error) {
             log.error(`Mesh V2: Failed to join group: ${error}`);


### PR DESCRIPTION
This PR fixes the 'coerced Null value for NonNull type String!' GraphQL error when connecting to Mesh V2 without a domain in the URL. It also ensures that the auto-generated domain from the server is correctly tracked and used by the client.

- Updated operation definitions to allow null domain (matching schema)
- Added domain tracking from server responses
- Updated unit tests