### PR TITLE
feat: implement createDomain and mandatory domain validation

### DIFF
--- a/src/extensions/scratch3_mesh_v2/gql-operations.js
+++ b/src/extensions/scratch3_mesh_v2/gql-operations.js
@@ -2,7 +2,7 @@ const gqlTag = require('graphql-tag');
 const gql = gqlTag.default || gqlTag;
 
 const LIST_GROUPS_BY_DOMAIN = gql`
-  query ListGroupsByDomain($domain: String) {
+  query ListGroupsByDomain($domain: String!) {
     listGroupsByDomain(domain: $domain) {
       id
       domain
@@ -14,8 +14,14 @@ const LIST_GROUPS_BY_DOMAIN = gql`
   }
 `;
 
+const CREATE_DOMAIN = gql`
+  mutation CreateDomain {
+    createDomain
+  }
+`;
+
 const CREATE_GROUP = gql`
-  mutation CreateGroup($name: String!, $hostId: ID!, $domain: String) {
+  mutation CreateGroup($name: String!, $hostId: ID!, $domain: String!) {
     createGroup(name: $name, hostId: $hostId, domain: $domain) {
       id
       domain
@@ -127,6 +133,7 @@ const ON_GROUP_DISSOLVE = gql`
 
 module.exports = {
     LIST_GROUPS_BY_DOMAIN,
+    CREATE_DOMAIN,
     CREATE_GROUP,
     JOIN_GROUP,
     LEAVE_GROUP,

--- a/src/extensions/scratch3_mesh_v2/index.js
+++ b/src/extensions/scratch3_mesh_v2/index.js
@@ -213,18 +213,19 @@ class Scratch3MeshV2Blocks {
     /* istanbul ignore next */
     connectedMessage () {
         if (this.meshService && this.meshService.groupId) {
+            const meshIdWithDomain = `${this.meshService.groupId}@${this.meshService.domain}`;
             if (this.meshService.isHost) {
                 return formatMessage({
                     id: 'mesh.registeredHostV2',
                     default: 'Registered Host Mesh V2 [{ MESH_ID }]',
                     description: 'label for registered Host Mesh in connect modal for Mesh V2 extension'
-                }, {MESH_ID: this.meshService.groupId});
+                }, {MESH_ID: meshIdWithDomain});
             }
             return formatMessage({
                 id: 'mesh.joinedMeshV2',
                 default: 'Joined Mesh V2 [{ MESH_ID }]',
                 description: 'label for joined Mesh in connect modal for Mesh V2 extension'
-            }, {MESH_ID: this.meshService.groupId});
+            }, {MESH_ID: meshIdWithDomain});
         }
         return formatMessage({
             id: 'mesh.notConnectedV2',


### PR DESCRIPTION
This PR implements the createDomain mutation and ensures domain is mandatory for all GraphQL operations in Mesh V2.

Changes:
- Updated GraphQL operations to match the new schema.
- Added automatic domain generation in MeshV2Service using the new createDomain mutation.