### PR TITLE
feat: Mesh V2 improvements (UI, event handler, production config)

### DIFF
--- a/src/extensions/scratch3_mesh_v2/gql-operations.js
+++ b/src/extensions/scratch3_mesh_v2/gql-operations.js
@@ -22,8 +22,8 @@ const CREATE_DOMAIN = gql`
 `;
 
 const CREATE_GROUP = gql`
-  mutation CreateGroup($name: String!, $hostId: ID!, $domain: String!) {
-    createGroup(name: $name, hostId: $hostId, domain: $domain) {
+  mutation CreateGroup($name: String!, $hostId: ID!, $domain: String!, $maxConnectionTimeSeconds: Int) {
+    createGroup(name: $name, hostId: $hostId, domain: $domain, maxConnectionTimeSeconds: $maxConnectionTimeSeconds) {
       id
       domain
       fullId

--- a/src/extensions/scratch3_mesh_v2/index.js
+++ b/src/extensions/scratch3_mesh_v2/index.js
@@ -17,12 +17,31 @@ const blockIconURI = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAYA
 
 const MESH_V2_HOST_ID = 'meshV2_host';
 
+const MESH_ID_LABEL_CHARACTERS = {
+    0: 'い',
+    1: 'し',
+    2: 'か',
+    3: 'た',
+    4: 'う',
+    5: 'ん',
+    6: 'て',
+    7: 'と',
+    8: 'の',
+    9: 'つ',
+    a: 'は',
+    b: 'こ',
+    c: 'に',
+    d: 'な',
+    e: 'く',
+    f: 'き'
+};
+
 class Scratch3MeshV2Blocks {
     /**
      * @return {string} - the name of this extension.
      */
     static get EXTENSION_NAME () {
-        return 'Mesh V2 (GraphQL)';
+        return 'Mesh V2';
     }
 
     static get EXTENSION_ID () {
@@ -53,6 +72,11 @@ class Scratch3MeshV2Blocks {
         }
 
         this.runtime.registerPeripheralExtension(Scratch3MeshV2Blocks.EXTENSION_ID, this);
+    }
+
+    makeMeshIdLabel (meshId) {
+        const label = meshId.slice(0, 6);
+        return [...label].map(c => MESH_ID_LABEL_CHARACTERS[c]).join('');
     }
 
     /* istanbul ignore next */
@@ -147,7 +171,7 @@ class Scratch3MeshV2Blocks {
                     id: 'mesh.clientPeripheralNameV2',
                     default: 'Join Mesh V2 [{ MESH_ID }]',
                     description: 'label for joining Mesh in connect modal for Mesh V2 extension'
-                }, {MESH_ID: group.name}),
+                }, {MESH_ID: this.makeMeshIdLabel(group.name)}),
                 rssi: 0,
                 domain: group.domain
             }));
@@ -159,7 +183,7 @@ class Scratch3MeshV2Blocks {
                     id: 'mesh.hostPeripheralNameV2',
                     default: 'Become Mesh V2 Host [{ MESH_ID }]',
                     description: 'label for becoming Host Mesh in connect modal for Mesh V2 extension'
-                }, {MESH_ID: this.nodeId.slice(0, 6)}),
+                }, {MESH_ID: this.makeMeshIdLabel(this.nodeId)}),
                 rssi: 0
             });
 
@@ -179,7 +203,7 @@ class Scratch3MeshV2Blocks {
         if (!this.meshService) return;
 
         if (id === MESH_V2_HOST_ID) {
-            this.meshService.createGroup(`${this.nodeId.slice(0, 6)}'s Mesh`).then(() => {
+            this.meshService.createGroup(this.nodeId).then(() => {
                 this.runtime.emit(this.runtime.constructor.PERIPHERAL_CONNECTED);
             })
                 /* istanbul ignore next */
@@ -216,7 +240,7 @@ class Scratch3MeshV2Blocks {
     /* istanbul ignore next */
     connectedMessage () {
         if (this.meshService && this.meshService.groupId) {
-            const meshIdWithDomain = `${this.meshService.groupId}@${this.meshService.domain}`;
+            const meshIdLabel = this.makeMeshIdLabel(this.meshService.groupName);
             const expiresAt = this.meshService.expiresAt ?
                 new Date(this.meshService.expiresAt).toLocaleTimeString([], {
                     hour: '2-digit',
@@ -235,7 +259,7 @@ class Scratch3MeshV2Blocks {
                     default: 'Registered Host Mesh V2 [{ MESH_ID }]{ EXPIRES_AT }',
                     description: 'label for registered Host Mesh in connect modal for Mesh V2 extension'
                 }, {
-                    MESH_ID: meshIdWithDomain,
+                    MESH_ID: meshIdLabel,
                     EXPIRES_AT: expiresAtMessage
                 });
             }
@@ -243,7 +267,7 @@ class Scratch3MeshV2Blocks {
                 id: 'mesh.joinedMeshV2',
                 default: 'Joined Mesh V2 [{ MESH_ID }]',
                 description: 'label for joined Mesh in connect modal for Mesh V2 extension'
-            }, {MESH_ID: meshIdWithDomain});
+            }, {MESH_ID: meshIdLabel});
         }
         return formatMessage({
             id: 'mesh.notConnectedV2',

--- a/src/extensions/scratch3_mesh_v2/index.js
+++ b/src/extensions/scratch3_mesh_v2/index.js
@@ -57,7 +57,7 @@ class Scratch3MeshV2Blocks {
 
         try {
             createClient();
-            this.meshService = new MeshV2Service(this.nodeId, this.domain);
+            this.meshService = new MeshV2Service(this, this.nodeId, this.domain);
             this.meshService.setDisconnectCallback(() => {
                 this.runtime.emit(this.runtime.constructor.PERIPHERAL_DISCONNECTED);
             });

--- a/src/extensions/scratch3_mesh_v2/index.js
+++ b/src/extensions/scratch3_mesh_v2/index.js
@@ -75,6 +75,7 @@ class Scratch3MeshV2Blocks {
     }
 
     makeMeshIdLabel (meshId) {
+        if (!meshId) return '';
         const label = meshId.slice(0, 6);
         return [...label].map(c => MESH_ID_LABEL_CHARACTERS[c]).join('');
     }
@@ -214,7 +215,8 @@ class Scratch3MeshV2Blocks {
         } else {
             const group = this.discoveredGroups && this.discoveredGroups.find(g => g.id === id);
             const domain = group ? group.domain : null;
-            this.meshService.joinGroup(id, domain).then(() => {
+            const groupName = group ? group.name : id;
+            this.meshService.joinGroup(id, domain, groupName).then(() => {
                 this.runtime.emit(this.runtime.constructor.PERIPHERAL_CONNECTED);
             })
                 /* istanbul ignore next */

--- a/src/extensions/scratch3_mesh_v2/mesh-client.js
+++ b/src/extensions/scratch3_mesh_v2/mesh-client.js
@@ -2,10 +2,10 @@ const AWSAppSyncClient = require('aws-appsync').default;
 const gqlTag = require('graphql-tag');
 const gql = gqlTag.default || gqlTag;
 
-// TODO: Replace with actual configuration or environment variables
-const GRAPHQL_ENDPOINT = process.env.MESH_GRAPHQL_ENDPOINT || 'https://example.com/graphql';
-const REGION = process.env.MESH_AWS_REGION || 'us-east-1';
-const API_KEY = process.env.MESH_API_KEY || 'da2-example';
+// Production configuration for Smalruby 3 Mesh V2
+const GRAPHQL_ENDPOINT = process.env.MESH_GRAPHQL_ENDPOINT || 'https://mpe3yhgk6zdxfhjbay2vqcq5qe.appsync-api.ap-northeast-1.amazonaws.com/graphql';
+const REGION = process.env.MESH_AWS_REGION || 'ap-northeast-1';
+const API_KEY = process.env.MESH_API_KEY || 'da2-kdkm7p5cfzbr5jsikmoqvddowi';
 
 let client = null;
 

--- a/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -1,6 +1,7 @@
 const log = require('../../util/log');
 const {getClient} = require('./mesh-client');
 const RateLimiter = require('./rate-limiter');
+const BlockUtility = require('../../engine/block-utility');
 const {
     LIST_GROUPS_BY_DOMAIN,
     CREATE_DOMAIN,
@@ -21,8 +22,10 @@ const CONNECTION_TIMEOUT = 50 * 60 * 1000; // 50 minutes in milliseconds
 
 /* istanbul ignore next */
 class MeshV2Service {
-    constructor (meshId, domain) {
+    constructor (blocks, meshId, domain) {
         log.info('Initializing MeshV2Service (GraphQL)');
+        this.blocks = blocks;
+        this.runtime = blocks.runtime;
         this.meshId = meshId;
         this.domain = domain;
         this.client = getClient();
@@ -272,8 +275,23 @@ class MeshV2Service {
 
     handleEvent (event) {
         if (!event || event.firedByNodeId === this.meshId) return;
-        // Event handling will be implemented in Phase 3 blocks
         log.info(`Mesh V2: Received event ${event.name} from ${event.firedByNodeId}`);
+
+        try {
+            const args = {
+                BROADCAST_OPTION: {
+                    id: null,
+                    name: event.name
+                }
+            };
+            const util = BlockUtility.lastInstance();
+            if (!util.sequencer) {
+                util.sequencer = this.runtime.sequencer;
+            }
+            this.blocks.opcodeFunctions.event_broadcast(args, util);
+        } catch (error) {
+            log.error(`Mesh V2: Failed to broadcast event: ${error}`);
+        }
     }
 
     startHeartbeat () {

--- a/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -139,7 +139,7 @@ class MeshV2Service {
         }
     }
 
-    async joinGroup (groupId, domain) {
+    async joinGroup (groupId, domain, groupName) {
         if (!this.client) throw new Error('Client not initialized');
 
         try {
@@ -154,6 +154,7 @@ class MeshV2Service {
 
             const node = result.data.joinGroup;
             this.groupId = groupId;
+            this.groupName = groupName || groupId;
             this.domain = node.domain; // Update domain from server
             this.isHost = false;
             if (node.heartbeatIntervalSeconds) {

--- a/test/unit/extension_mesh_v2.js
+++ b/test/unit/extension_mesh_v2.js
@@ -96,7 +96,7 @@ test('Mesh V2 Blocks', t => {
 
         // Mock service methods
         blocks.meshService.createGroup = name => {
-            st.ok(name.includes("'s Mesh"));
+            st.equal(name, blocks.nodeId);
             // Simulate server returning auto-generated domain
             blocks.meshService.domain = 'auto-domain';
             return Promise.resolve({id: 'new-group-id', domain: 'auto-domain'});
@@ -120,9 +120,10 @@ test('Mesh V2 Blocks', t => {
         blocks.discoveredGroups = [{id: 'group1', name: 'Group 1', domain: 'scanned-domain'}];
 
         // Mock service methods
-        blocks.meshService.joinGroup = (id, domain) => {
+        blocks.meshService.joinGroup = (id, domain, groupName) => {
             st.equal(id, 'group1');
             st.equal(domain, 'scanned-domain');
+            st.equal(groupName, 'Group 1');
             blocks.meshService.domain = domain;
             return Promise.resolve({id: 'node1', domain: domain});
         };


### PR DESCRIPTION
This PR implements several improvements for the Mesh V2 extension based on Issue #469 in smalruby3-gui.

### Key Changes

1.  **Improved Connection UI**
    *   Added `MESH_ID_LABEL_CHARACTERS` and `makeMeshIdLabel()` to convert cryptic node/group IDs into user-friendly labels (e.g., "なにうとてに").
    *   Used labels in the connection modal for both hosting and joining.
    *   Set the initial group name for hosts to the full `nodeId`.
    *   Updated the connection status message to show the group name label.

2.  **Event Handler Implementation**
    *   Updated `MeshV2Service` to hold references to `blocks` and `runtime`.
    *   Implemented `handleEvent()` to integrate received Mesh events with the Scratch broadcast system using `event_broadcast`.
    *   Imported `BlockUtility` for proper execution context.

3.  **Extension Renaming**
    *   Renamed the extension from "Mesh V2 (GraphQL)" to "Mesh V2".

4.  **Production Configuration**
    *   Updated hardcoded defaults in `mesh-client.js` with production AppSync endpoint, region, and API key.
    *   Updated `CREATE_GROUP` mutation to support the optional `maxConnectionTimeSeconds` parameter.

🤖 Generated with [Gemini Code](https://gemini.google.com/code)

Co-Authored-By: Gemini <noreply@google.com>