### PR TITLE
feat: add Runtime.BEFORE_STEP event and use it for frame-synchronized broadcasts in meshV2

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -519,6 +519,14 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Event name for when a frame step is about to begin.
+     * @const {string}
+     */
+    static get BEFORE_STEP () {
+        return 'BEFORE_STEP';
+    }
+
+    /**
      * Event name for target being stopped by a stop for target call.
      * Used by blocks that need to stop individual targets.
      * @const {string}
@@ -2314,6 +2322,8 @@ class Runtime extends EventEmitter {
             }
             this.profiler.start(stepProfilerId);
         }
+
+        this.emit(Runtime.BEFORE_STEP);
 
         // Clean up threads that were told to stop during or since the last step
         this.threads = this.threads.filter(thread => !thread.isKilled);

--- a/test/unit/mesh_service_v2.js
+++ b/test/unit/mesh_service_v2.js
@@ -16,164 +16,95 @@ const createMockBlocks = () => ({
 });
 
 // Mock BlockUtility.lastInstance()
-
 const originalLastInstance = BlockUtility.lastInstance;
-
 const mockUtil = null;
-
 BlockUtility.lastInstance = () => mockUtil;
 
-
 test('MeshV2Service Batch Events', t => {
-
     t.test('fireEvent adds to queue', st => {
-
         const blocks = createMockBlocks();
-
         const service = new MeshV2Service(blocks, 'node1', 'domain1');
-
         service.stopEventBatchTimer(); // Stop timer to prevent interference
-
         service.client = {mutate: () => Promise.resolve({})};
-
         service.groupId = 'group1';
-        
 
         service.fireEvent('event1', 'payload1');
 
         // Give it a tiny bit of time if needed, though await should be enough
-
         st.equal(service.eventQueue.length, 1);
-
         st.equal(service.eventQueue[0].eventName, 'event1');
-
         st.equal(service.eventQueue[0].payload, 'payload1');
-
         st.ok(service.eventQueue[0].firedAt);
-        
 
         st.end();
-
     });
 
-
     t.test('processBatchEvents sends events and clears queue', async st => {
-
         const blocks = createMockBlocks();
-
         const service = new MeshV2Service(blocks, 'node1', 'domain1');
-
         service.stopEventBatchTimer();
-
         service.groupId = 'group1';
 
         service.client = {
-
             mutate: options => {
-
                 st.equal(options.mutation, FIRE_EVENTS);
-
                 st.equal(options.variables.events.length, 2);
-
                 return Promise.resolve({data: {fireEventsByNode: {}}});
-
             }
-
         };
 
-
         service.eventQueue.push({eventName: 'e1', payload: 'p1', firedAt: 't1'});
-
         service.eventQueue.push({eventName: 'e2', payload: 'p2', firedAt: 't2'});
 
-
         await service.processBatchEvents();
-
         st.equal(service.eventQueue.length, 0);
-        
 
         st.end();
-
     });
 
-
     t.test('processBatchEvents splits large batches', async st => {
-
         const blocks = createMockBlocks();
-
         const service = new MeshV2Service(blocks, 'node1', 'domain1');
-
         service.stopEventBatchTimer();
-
         service.groupId = 'group1';
 
         let mutateCount = 0;
-
         service.client = {
-
             mutate: options => {
-
                 mutateCount++;
-
                 if (mutateCount === 1) {
-
                     st.equal(options.variables.events.length, 1000);
-
                 } else {
-
                     st.equal(options.variables.events.length, 500);
-
                 }
-
                 return Promise.resolve({data: {fireEventsByNode: {}}});
-
             }
-
         };
 
-
         for (let i = 0; i < 1500; i++) {
-
             service.eventQueue.push({eventName: 'e', payload: 'p', firedAt: 't'});
-
         }
 
-
         await service.processBatchEvents();
-
         st.equal(mutateCount, 2);
-
         st.equal(service.eventQueue.length, 0);
-        
 
         st.end();
-
     });
 
-
     t.test('handleBatchEvent broadcast events with timing', st => {
-
         const blocks = createMockBlocks();
-
         const service = new MeshV2Service(blocks, 'node1', 'domain1');
 
         const events = [
-
             {name: 'event1', timestamp: '2025-12-30T00:00:00.000Z'},
-
             {name: 'event2', timestamp: '2025-12-30T00:00:00.100Z'},
-
             {name: 'event3', timestamp: '2025-12-30T00:00:00.200Z'}
-
         ];
 
-
         const batchEvent = {
-
             firedByNodeId: 'node2',
-
             events: events
-
         };
 
         service.handleBatchEvent(batchEvent);

--- a/test/unit/mesh_service_v2.js
+++ b/test/unit/mesh_service_v2.js
@@ -16,91 +16,164 @@ const createMockBlocks = () => ({
 });
 
 // Mock BlockUtility.lastInstance()
+
 const originalLastInstance = BlockUtility.lastInstance;
-let mockUtil = null;
+
+const mockUtil = null;
+
 BlockUtility.lastInstance = () => mockUtil;
 
+
 test('MeshV2Service Batch Events', t => {
+
     t.test('fireEvent adds to queue', st => {
+
         const blocks = createMockBlocks();
+
         const service = new MeshV2Service(blocks, 'node1', 'domain1');
+
         service.stopEventBatchTimer(); // Stop timer to prevent interference
+
         service.client = {mutate: () => Promise.resolve({})};
+
         service.groupId = 'group1';
         
+
         service.fireEvent('event1', 'payload1');
+
         // Give it a tiny bit of time if needed, though await should be enough
+
         st.equal(service.eventQueue.length, 1);
+
         st.equal(service.eventQueue[0].eventName, 'event1');
+
         st.equal(service.eventQueue[0].payload, 'payload1');
+
         st.ok(service.eventQueue[0].firedAt);
         
+
         st.end();
+
     });
+
 
     t.test('processBatchEvents sends events and clears queue', async st => {
+
         const blocks = createMockBlocks();
+
         const service = new MeshV2Service(blocks, 'node1', 'domain1');
+
         service.stopEventBatchTimer();
+
         service.groupId = 'group1';
+
         service.client = {
+
             mutate: options => {
+
                 st.equal(options.mutation, FIRE_EVENTS);
+
                 st.equal(options.variables.events.length, 2);
+
                 return Promise.resolve({data: {fireEventsByNode: {}}});
+
             }
+
         };
+
 
         service.eventQueue.push({eventName: 'e1', payload: 'p1', firedAt: 't1'});
+
         service.eventQueue.push({eventName: 'e2', payload: 'p2', firedAt: 't2'});
 
+
         await service.processBatchEvents();
+
         st.equal(service.eventQueue.length, 0);
         
+
         st.end();
+
     });
+
 
     t.test('processBatchEvents splits large batches', async st => {
+
         const blocks = createMockBlocks();
+
         const service = new MeshV2Service(blocks, 'node1', 'domain1');
+
         service.stopEventBatchTimer();
+
         service.groupId = 'group1';
+
         let mutateCount = 0;
+
         service.client = {
+
             mutate: options => {
+
                 mutateCount++;
+
                 if (mutateCount === 1) {
+
                     st.equal(options.variables.events.length, 1000);
+
                 } else {
+
                     st.equal(options.variables.events.length, 500);
+
                 }
+
                 return Promise.resolve({data: {fireEventsByNode: {}}});
+
             }
+
         };
 
+
         for (let i = 0; i < 1500; i++) {
+
             service.eventQueue.push({eventName: 'e', payload: 'p', firedAt: 't'});
+
         }
 
+
         await service.processBatchEvents();
+
         st.equal(mutateCount, 2);
+
         st.equal(service.eventQueue.length, 0);
         
+
         st.end();
+
     });
 
+
     t.test('handleBatchEvent broadcast events with timing', st => {
+
         const blocks = createMockBlocks();
+
         const service = new MeshV2Service(blocks, 'node1', 'domain1');
+
         const events = [
-            { name: 'event1', timestamp: '2025-12-30T00:00:00.000Z' },
-            { name: 'event2', timestamp: '2025-12-30T00:00:00.100Z' },
-            { name: 'event3', timestamp: '2025-12-30T00:00:00.200Z' }
+
+            {name: 'event1', timestamp: '2025-12-30T00:00:00.000Z'},
+
+            {name: 'event2', timestamp: '2025-12-30T00:00:00.100Z'},
+
+            {name: 'event3', timestamp: '2025-12-30T00:00:00.200Z'}
+
         ];
 
+
         const batchEvent = {
+
             firedByNodeId: 'node2',
+
             events: events
+
         };
 
         service.handleBatchEvent(batchEvent);

--- a/test/unit/mesh_service_v2_integration.js
+++ b/test/unit/mesh_service_v2_integration.js
@@ -23,7 +23,6 @@ test('MeshV2Service Integration: Batching and Timing', async t => {
     });
 
     // Mock BlockUtility
-    const originalLastInstance = BlockUtility.lastInstance;
     BlockUtility.lastInstance = () => ({
         sequencer: blocks.runtime.sequencer
     });

--- a/test/unit/mesh_service_v2_integration.js
+++ b/test/unit/mesh_service_v2_integration.js
@@ -5,7 +5,9 @@ const BlockUtility = require('../../src/engine/block-utility');
 const createMockBlocks = broadcastCallback => ({
     runtime: {
         sequencer: {},
-        emit: () => {}
+        emit: () => {},
+        on: () => {},
+        off: () => {}
     },
     opcodeFunctions: {
         event_broadcast: args => {
@@ -63,23 +65,28 @@ test('MeshV2Service Integration: Batching and Timing', async t => {
     // 2. Process batch (simulates timer trigger)
     await sender.processBatchEvents();
 
-    // 3. Verify timing reproduction
-    t.equal(broadcasted.length, 1, 'First event should be broadcasted immediately');
+    // 3. Verify queuing
+    t.equal(receiver.pendingBroadcasts.length, 3, 'Events should be queued');
+    t.equal(receiver.pendingBroadcasts[0].name, 'e1');
+    t.equal(receiver.pendingBroadcasts[1].name, 'e2');
+    t.equal(receiver.pendingBroadcasts[2].name, 'e3');
+
+    // 4. Process events via BEFORE_STEP simulation
+    receiver.processNextBroadcast();
+    t.equal(broadcasted.length, 1);
     t.equal(broadcasted[0].name, 'e1');
+    t.equal(receiver.pendingBroadcasts.length, 2);
 
-    await new Promise(r => setTimeout(r, 150));
-    t.equal(broadcasted.length, 2, 'Second event should be broadcasted after ~100ms');
+    receiver.processNextBroadcast();
+    t.equal(broadcasted.length, 2);
     t.equal(broadcasted[1].name, 'e2');
-    t.ok(broadcasted[1].time - broadcasted[0].time >= 100, 'Interval between e1 and e2 should be at least 100ms');
+    t.equal(receiver.pendingBroadcasts.length, 1);
 
-    await new Promise(r => setTimeout(r, 100));
-    t.equal(broadcasted.length, 3, 'Third event should be broadcasted after ~200ms total');
+    receiver.processNextBroadcast();
+    t.equal(broadcasted.length, 3);
     t.equal(broadcasted[2].name, 'e3');
-    t.ok(broadcasted[2].time - broadcasted[1].time >= 100, 'Interval between e2 and e3 should be at least 100ms');
+    t.equal(receiver.pendingBroadcasts.length, 0);
 
-    // Restore
-    // eslint-disable-next-line require-atomic-updates
-    BlockUtility.lastInstance = originalLastInstance;
     t.end();
 });
 


### PR DESCRIPTION
## Summary
This PR adds a new `Runtime.BEFORE_STEP` event to Scratch VM and modifies the Mesh V2 extension to use this event for frame-synchronized broadcasts.

## Changes
- **Runtime**: Added `BEFORE_STEP` event constant and emission at the beginning of each `_step()`.
- **Mesh V2**:
    - Modified `MeshV2Service` to listen for `BEFORE_STEP` event.
    - Replaced `setTimeout`-based broadcast scheduling with a `pendingBroadcasts` queue.
    - Implemented `processNextBroadcast()` which executes one queued broadcast per frame step.
- **Tests**: Updated unit and integration tests to verify the new queue-based broadcast logic.

## Purpose
In Mesh V2 batch event sending, receiving multiple events in a short interval previously caused multiple broadcasts to fire in the same frame. Due to Scratch VM's behavior, this would restart the same message's scripts, causing processing to be lost. By synchronizing broadcasts with frame steps (one per frame), we ensure every event is correctly processed.

Related Issue: smalruby/smalruby3-gui#475
Related Issue: smalruby/smalruby3-gui#473