### PR TITLE
feat: implement data merge feature in RateLimiter for Mesh V2

### DIFF
--- a/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -57,7 +57,6 @@ class MeshV2Service {
             enableMerge: true,
             mergeKeyField: 'key'
         });
-        this.eventRateLimiter = new RateLimiter(2, 500); // 2 times/sec, 500ms interval
 
         // Event queue for batch sending: { eventName, payload, firedAt } の配列
         this.eventQueue = [];
@@ -77,7 +76,11 @@ class MeshV2Service {
         this._processNextBroadcastBound = this.processNextBroadcast.bind(this);
         this.runtime.on('BEFORE_STEP', this._processNextBroadcastBound);
 
-        // Fixed reference for RateLimiter merge comparison
+        /**
+         * Bound reference to _reportData for RateLimiter merge comparison.
+         * This ensures consistent sendFunction reference across multiple calls.
+         * @private
+         */
         this._reportDataBound = this._reportData.bind(this);
 
         this.disconnectCallback = null;

--- a/test/integration/extensions/mesh-v2-data-merge.test.js
+++ b/test/integration/extensions/mesh-v2-data-merge.test.js
@@ -1,0 +1,94 @@
+const test = require('tap').test;
+const MeshV2Service = require('../../../src/extensions/scratch3_mesh_v2/mesh-service');
+const {REPORT_DATA} = require('../../../src/extensions/scratch3_mesh_v2/gql-operations');
+
+// Mock MeshClient
+const mockClient = {
+    mutate: null,
+    subscribe: () => ({
+        subscribe: () => ({
+            unsubscribe: () => {}
+        })
+    })
+};
+
+require('../../../src/extensions/scratch3_mesh_v2/mesh-client').getClient = () => mockClient;
+
+test('MeshV2Service Data Merge Integration', async t => {
+    let mutateCount = 0;
+    const mutations = [];
+    
+    // Custom mock mutate to track calls
+    mockClient.mutate = async ({mutation, variables}) => {
+        if (mutation === REPORT_DATA) {
+            mutateCount++;
+            mutations.push(JSON.parse(JSON.stringify(variables.data)));
+            // Simulate network delay
+            await new Promise(resolve => setTimeout(resolve, 50));
+        }
+        return {data: {}};
+    };
+
+    const service = new MeshV2Service({
+        runtime: {
+            on: () => {},
+            off: () => {}
+        }
+    }, 'node1', 'domain1');
+    
+    service.groupId = 'group1';
+    service.client = mockClient;
+
+    // Send 1st: starts processing immediately
+    service.sendData([{key: 'v1', value: 1}]);
+    
+    // Send 2nd, 3rd, 4th: should be merged into ONE call
+    service.sendData([{key: 'v1', value: 2}]);
+    service.sendData([{key: 'v1', value: 3}]);
+    service.sendData([{key: 'v1', value: 4}]);
+
+    await service.dataRateLimiter.waitForCompletion();
+
+    t.equal(mutateCount, 2, 'Should only result in 2 API calls (1st + merged 2nd/3rd/4th)');
+    t.same(mutations[0], [{key: 'v1', value: 1}]);
+    t.same(mutations[1], [{key: 'v1', value: 4}]);
+    
+    t.end();
+});
+
+test('MeshV2Service Data Unchanged Detection', async t => {
+
+    let mutateCount = 0;
+
+    mockClient.mutate = () => {
+
+        mutateCount++;
+
+        return Promise.resolve({data: {}});
+
+    };
+
+
+    const service = new MeshV2Service({
+        runtime: {
+            on: () => {},
+            off: () => {}
+        }
+    }, 'node1', 'domain1');
+    service.groupId = 'group1';
+    service.client = mockClient;
+
+    // First send
+    await service.sendData([{key: 'v1', value: 100}]);
+    t.equal(mutateCount, 1);
+
+    // Send same data again
+    await service.sendData([{key: 'v1', value: 100}]);
+    t.equal(mutateCount, 1, 'Should NOT send if data is unchanged');
+
+    // Send changed data
+    await service.sendData([{key: 'v1', value: 101}]);
+    t.equal(mutateCount, 2, 'Should send if data is changed');
+
+    t.end();
+});

--- a/test/unit/rate_limiter.js
+++ b/test/unit/rate_limiter.js
@@ -1,0 +1,148 @@
+const test = require('tap').test;
+const RateLimiter = require('../../src/extensions/scratch3_mesh_v2/rate-limiter');
+
+test('RateLimiter Basic', t => {
+    const limiter = new RateLimiter(4, 10);
+    let count = 0;
+    
+    const pendingResolves = [];
+    const slowSendFn = data => {
+        count += data;
+        return new Promise(resolve => {
+            pendingResolves.push(resolve);
+        });
+    };
+
+    limiter.send(1, slowSendFn);
+    limiter.send(2, slowSendFn);
+
+    t.equal(limiter.queue.length, 1, 'Item 2 should be in queue');
+    t.ok(limiter.processing, 'Limiter should be processing item 1');
+    
+    // Resolve all items as they come
+    const interval = setInterval(() => {
+        if (pendingResolves.length > 0) {
+            const resolve = pendingResolves.shift();
+            resolve();
+        }
+    }, 50);
+    
+    return limiter.waitForCompletion().then(() => {
+        clearInterval(interval);
+        t.equal(count, 3, 'Both items should be processed');
+        t.equal(limiter.queue.length, 0, 'Queue should be empty');
+        t.end();
+    });
+});
+
+test('RateLimiter Merge Feature', t => {
+    const limiter = new RateLimiter(4, 10, {
+        enableMerge: true,
+        mergeKeyField: 'key'
+    });
+    
+    const sentData = [];
+    const pendingResolves = [];
+    
+    const slowSendFn = data => {
+        // Clone data to avoid reference changes in tests
+        sentData.push(JSON.parse(JSON.stringify(data)));
+        return new Promise(resolve => {
+            pendingResolves.push(resolve);
+        });
+    };
+
+    // Send 1: starts processing
+    limiter.send([{key: 'var1', value: 1}], slowSendFn);
+    
+    // Send 2 & 3: should be merged into ONE item in queue
+    limiter.send([{key: 'var1', value: 2}], slowSendFn);
+    limiter.send([{key: 'var1', value: 3}], slowSendFn);
+
+    t.equal(limiter.queue.length, 1, 'Queue should have 1 item (merged send 2 & 3)');
+    t.equal(limiter.queue[0].data[0].value, 3, 'Latest value should be in queue');
+
+    // Resolve items as they come
+    const interval = setInterval(() => {
+        if (pendingResolves.length > 0) {
+            const resolve = pendingResolves.shift();
+            resolve(true);
+        }
+    }, 50);
+
+    // After Send 1 finishes, Send 2/3 (merged) will start after interval
+    return limiter.waitForCompletion().then(() => {
+        clearInterval(interval);
+        t.equal(sentData.length, 2, 'Total 2 sends: Send 1 + Merged(Send 2, Send 3)');
+        t.same(sentData[0], [{key: 'var1', value: 1}]);
+        t.same(sentData[1], [{key: 'var1', value: 3}]);
+        t.end();
+    });
+});
+
+test('RateLimiter Merge Different Keys in same Send', t => {
+
+    const limiter = new RateLimiter(4, 10, {
+
+        enableMerge: true,
+
+        mergeKeyField: 'key'
+
+    });
+    
+
+    const pendingResolves = [];
+
+    const slowSendFn = () => new Promise(resolve => {
+        pendingResolves.push(resolve);
+    });
+
+
+    // Send 1
+
+    limiter.send([{key: 'v1', value: 1}], slowSendFn);
+    
+
+    // Send 2: updates v1, adds v2
+
+    limiter.send([{key: 'v1', value: 2}, {key: 'v2', value: 10}], slowSendFn);
+
+
+    t.equal(limiter.queue.length, 1);
+
+    t.equal(limiter.queue[0].data.length, 2);
+    
+
+    const v1 = limiter.queue[0].data.find(i => i.key === 'v1');
+
+    const v2 = limiter.queue[0].data.find(i => i.key === 'v2');
+
+    t.equal(v1.value, 2);
+
+    t.equal(v2.value, 10);
+
+
+    // Resolve items as they come
+
+    const interval = setInterval(() => {
+
+        if (pendingResolves.length > 0) {
+
+            const resolve = pendingResolves.shift();
+
+            resolve(true);
+
+        }
+
+    }, 50);
+
+
+    return limiter.waitForCompletion().then(() => {
+
+        clearInterval(interval);
+
+        t.end();
+
+    });
+
+});


### PR DESCRIPTION
## Summary
This PR implements the data merge feature in the Mesh V2 extension's RateLimiter to reduce API requests and cost.

## Changes
- **RateLimiter Extension**: Added support for merging data items in the queue when the same  is used.
- **MeshV2Service Integration**: Enabled  for .
- **sendData Improvements**: Refactored  to use a bound method , ensuring consistent function references for RateLimiter's merge comparison.
- **Enhanced Logging**: Added detailed logs for data changes, merging, and request processing.
- **Comprehensive Testing**:
  - Added unit tests for  ().
  - Added integration tests for  data merging ().

## Verification Results
- All unit and integration tests passed.
- Linting clean.

Fixes #52

🤖 Generated with [Gemini Code](https://gemini.google.com/code)

Co-Authored-By: Gemini <noreply@google.com>