### PR TITLE
fix: ensure event processing continues after reconnecting to a new group

### DIFF
--- a/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -294,12 +294,6 @@ class MeshV2Service {
     }
 
     cleanup () {
-        // BEFORE_STEPイベントリスナーを削除
-        if (this._processNextBroadcastBound) {
-            this.runtime.off('BEFORE_STEP', this._processNextBroadcastBound);
-            this._processNextBroadcastBound = null;
-        }
-
         // キューをクリア
         this.pendingBroadcasts = [];
         this.batchStartTime = null;
@@ -421,6 +415,14 @@ class MeshV2Service {
      * - Events separated by frame intervals (>= 16.67ms) wait for real time to elapse
      */
     processNextBroadcast () {
+        if (!this.groupId) {
+            // 切断されている場合はキューをクリアして終了
+            this.pendingBroadcasts = [];
+            this.batchStartTime = null;
+            this.lastBroadcastOffset = 0;
+            return;
+        }
+
         if (this.pendingBroadcasts.length === 0) {
             // キューが空になったらリセット
             this.batchStartTime = null;


### PR DESCRIPTION
## Description
When a host disconnects and dissolves a group, then reconnects to a new group, broadcast events are no longer triggered even though events are being sent and received correctly.

The root cause was that `cleanup()` method was removing the `BEFORE_STEP` listener and setting the bound function reference to null, but the listener was only registered in the constructor. This prevented `processNextBroadcast()` from being called after a reconnect.

## Changes
- Keep `BEFORE_STEP` listener always active (don't remove it in `cleanup`).
- Add connection check in `processNextBroadcast()`:
  - If connected: process queue normally.
  - If disconnected: clear queue and return.
- Added unit tests to verify the fix.

## Test Coverage
- Verified with new unit tests in `test/unit/mesh_service_v2.js`.
- All `scratch-vm` unit tests passed.

Fixes smalruby/scratch-vm#58