### PR TITLE
perf: optimize processNextBroadcast to avoid redundant queue clearing

### DIFF
--- a/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -416,10 +416,7 @@ class MeshV2Service {
      */
     processNextBroadcast () {
         if (!this.groupId) {
-            // 切断されている場合はキューをクリアして終了
-            this.pendingBroadcasts = [];
-            this.batchStartTime = null;
-            this.lastBroadcastOffset = 0;
+            // 切断されている場合はなにもしない
             return;
         }
 


### PR DESCRIPTION
## Performance Optimization

This PR optimizes `processNextBroadcast()` by removing redundant queue clearing operations when disconnected.

## Problem

In PR #59, we added queue clearing logic in `processNextBroadcast()` when `!this.groupId`:

```javascript
if (!this.groupId) {
    // 切断されている場合はキューをクリアして終了
    this.pendingBroadcasts = [];
    this.batchStartTime = null;
    this.lastBroadcastOffset = 0;
    return;
}
```

However, this is **redundant** because:
1. `cleanup()` already clears the queue when disconnecting (line 304-306)
2. `processNextBroadcast()` is called **every frame** (BEFORE_STEP event)
3. At 60fps, this means **60 unnecessary clear operations per second**

## Solution

**Remove redundant clearing** from `processNextBroadcast()`:
```javascript
if (!this.groupId) {
    // 切断されている場合はなにもしない
    return;
}
```

**Responsibility separation**:
- `cleanup()`: Handles cleanup when disconnecting
- `processNextBroadcast()`: Handles event processing when connected

## Changes

### src/extensions/scratch3_mesh_v2/mesh-service.js
- Remove queue clearing logic from `processNextBroadcast()` when disconnected
- Update comment to reflect new behavior

### test/unit/mesh_service_v2.js
- Rename test: "processNextBroadcast clears queue when disconnected" → "processNextBroadcast does nothing when disconnected"
- Update assertions to verify state remains **unchanged** when disconnected
- Add new test: "cleanup clears event queue" to ensure `cleanup()` handles clearing

## Benefits

1. ✅ **Performance**: Eliminates ~60 array operations per second (at 60fps)
2. ✅ **Code Clarity**: Single responsibility - cleanup() cleans, processNextBroadcast() processes
3. ✅ **No Redundancy**: Queue clearing happens once in cleanup(), not every frame

## Test Coverage

- ✅ All tests pass
- ✅ 100% code coverage maintained for mesh-service.js
- ✅ New test verifies cleanup() responsibility

## Related

- Issue: #58
- Previous PR: #59 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>