### PR TITLE
fix: remove redundant fireMeshEvent block

### DIFF
--- a/src/extensions/scratch3_mesh_v2/index.js
+++ b/src/extensions/scratch3_mesh_v2/index.js
@@ -126,31 +126,12 @@ class Scratch3MeshV2Blocks {
                             defaultValue: ''
                         }
                     }
-                },
-                {
-                    opcode: 'fireMeshEvent',
-                    text: formatMessage({
-                        id: 'mesh.fireMeshEvent',
-                        default: 'send [BROADCAST_OPTION]',
-                        description: 'Fire a mesh event'
-                    }),
-                    blockType: BlockType.COMMAND,
-                    arguments: {
-                        BROADCAST_OPTION: {
-                            type: ArgumentType.STRING,
-                            menu: 'broadcastMessages'
-                        }
-                    }
                 }
             ],
             menus: {
                 variableNames: {
                     acceptReporters: true,
                     items: 'getVariableNamesMenuItems'
-                },
-                broadcastMessages: {
-                    acceptReporters: true,
-                    items: 'getBroadcastMessagesMenuItems'
                 }
             }
         };
@@ -168,19 +149,6 @@ class Scratch3MeshV2Blocks {
         const names = Object.values(this.meshService.remoteData)
             .reduce((acc, nodeData) => acc.concat(Object.keys(nodeData)), []);
         return [' '].concat([...new Set(names)]);
-    }
-
-    /* istanbul ignore next */
-    fireMeshEvent (args) {
-        if (!this.meshService) return;
-        return this.meshService.fireEvent(args.BROADCAST_OPTION);
-    }
-
-    /* istanbul ignore next */
-    getBroadcastMessagesMenuItems () {
-        const messages = this.runtime.getAllVarNamesOfType(Variable.BROADCAST_MESSAGE_TYPE);
-        if (messages.length < 1) return [' '];
-        return messages;
     }
 
     /* istanbul ignore next */

--- a/test/unit/extension_mesh_v2.js
+++ b/test/unit/extension_mesh_v2.js
@@ -65,7 +65,6 @@ test('Mesh V2 Blocks', t => {
         st.equal(info.id, 'meshV2');
         st.ok(info.blocks.length > 0);
         st.ok(info.menus.variableNames);
-        st.ok(info.menus.broadcastMessages);
         st.end();
     });
 
@@ -267,20 +266,6 @@ test('Mesh V2 Blocks', t => {
 
         st.equal(blocks.getSensorValue({NAME: 'var1'}), 'val1');
         st.equal(blocks.getSensorValue({NAME: 'var2'}), '');
-        st.end();
-    });
-
-    t.test('fireMeshEvent', st => {
-        const mockRuntime = createMockRuntime();
-        const blocks = new MeshV2Blocks(mockRuntime);
-        let firedEvent = null;
-        blocks.meshService.fireEvent = name => {
-            firedEvent = name;
-            return Promise.resolve();
-        };
-
-        blocks.fireMeshEvent({BROADCAST_OPTION: 'msg1'});
-        st.equal(firedEvent, 'msg1');
         st.end();
     });
 


### PR DESCRIPTION
## Summary
Removed the redundant `fireMeshEvent` block from the Mesh V2 extension.

## Implementation details
- Removed `fireMeshEvent` block definition from `getInfo()`.
- Removed `broadcastMessages` menu definition from `getInfo()`.
- Removed `fireMeshEvent(args)` method implementation.
- Removed `getBroadcastMessagesMenuItems()` method implementation.
- Removed the corresponding unit test case from `test/unit/extension_mesh_v2.js`.
- Updated `getInfo` test case to remove the check for `broadcastMessages` menu.

This block is no longer needed because the standard `event_broadcast` block already handles firing mesh events via the `setOpcodeFunctionHOC` mechanism in the Mesh V2 extension.

## Test coverage
- Ran unit tests: `npm run tap:unit test/unit/extension_mesh_v2.js` (Passed)
- Checked lint: `npm run lint` (Passed)

## Related Issue
Fixes #63
Related to smalruby/smalruby3-gui#454

Co-Authored-By: Gemini <noreply@google.com>