### PR TITLE
Improve error handling for expired Mesh V2 groups

### DIFF
--- a/test/unit/extension_mesh_v2.js
+++ b/test/unit/extension_mesh_v2.js
@@ -359,7 +359,7 @@ test('Mesh V2 Blocks', t => {
                 errorType: 'GroupNotFound'
             }]
         };
-        st.equal(blocks.meshService.shouldDisconnectOnError(groupNotFoundError), true);
+        st.equal(blocks.meshService.shouldDisconnectOnError(groupNotFoundError), 'GroupNotFound');
 
         // GraphQL errorType: Unauthorized
         const unauthorizedError = {
@@ -368,7 +368,7 @@ test('Mesh V2 Blocks', t => {
                 errorType: 'Unauthorized'
             }]
         };
-        st.equal(blocks.meshService.shouldDisconnectOnError(unauthorizedError), true);
+        st.equal(blocks.meshService.shouldDisconnectOnError(unauthorizedError), 'Unauthorized');
 
         // GraphQL errorType: NodeNotFound
         const nodeNotFoundError = {
@@ -377,7 +377,7 @@ test('Mesh V2 Blocks', t => {
                 errorType: 'NodeNotFound'
             }]
         };
-        st.equal(blocks.meshService.shouldDisconnectOnError(nodeNotFoundError), true);
+        st.equal(blocks.meshService.shouldDisconnectOnError(nodeNotFoundError), 'NodeNotFound');
 
         // GraphQL errorType: ValidationError (should NOT disconnect)
         const validationError = {
@@ -386,25 +386,25 @@ test('Mesh V2 Blocks', t => {
                 errorType: 'ValidationError'
             }]
         };
-        st.equal(blocks.meshService.shouldDisconnectOnError(validationError), false);
+        st.equal(blocks.meshService.shouldDisconnectOnError(validationError), null);
 
         // Fallback: message string matching
         const messageOnlyError = {
             message: 'GraphQL error: Group not found'
         };
-        st.equal(blocks.meshService.shouldDisconnectOnError(messageOnlyError), true);
+        st.equal(blocks.meshService.shouldDisconnectOnError(messageOnlyError), 'expired');
 
         const expiredMessageError = {
             message: 'Group expired'
         };
-        st.equal(blocks.meshService.shouldDisconnectOnError(expiredMessageError), true);
+        st.equal(blocks.meshService.shouldDisconnectOnError(expiredMessageError), 'expired');
 
         // Network error (should NOT disconnect)
         const networkError = {
             message: 'Network request failed',
             networkError: new Error('Fetch failed')
         };
-        st.equal(blocks.meshService.shouldDisconnectOnError(networkError), false);
+        st.equal(blocks.meshService.shouldDisconnectOnError(networkError), null);
 
         st.end();
     });

--- a/test/unit/extension_mesh_v2_issue66.js
+++ b/test/unit/extension_mesh_v2_issue66.js
@@ -1,0 +1,137 @@
+const test = require('tap').test;
+const URLSearchParams = require('url').URLSearchParams;
+const MeshV2Blocks = require('../../src/extensions/scratch3_mesh_v2/index.js');
+const Variable = require('../../src/engine/variable');
+
+const createMockRuntime = () => {
+    const runtime = {
+        registerPeripheralExtension: () => {},
+        on: () => {},
+        emit: (event, data) => {
+            if (!runtime.emittedEvents) runtime.emittedEvents = [];
+            runtime.emittedEvents.push({event, data});
+            runtime.lastEmittedEvent = event;
+            runtime.lastEmittedData = data;
+        },
+        getOpcodeFunction: () => () => {},
+        createNewGlobalVariable: name => ({type: Variable.SCALAR_TYPE, name: name || 'var1', value: 0}),
+        _primitives: {},
+        extensionManager: {
+            isExtensionLoaded: () => false
+        },
+        constructor: {
+            PERIPHERAL_LIST_UPDATE: 'PERIPHERAL_LIST_UPDATE',
+            PERIPHERAL_CONNECTED: 'PERIPHERAL_CONNECTED',
+            PERIPHERAL_DISCONNECTED: 'PERIPHERAL_DISCONNECTED',
+            PERIPHERAL_CONNECTION_ERROR_ID: 'PERIPHERAL_CONNECTION_ERROR_ID',
+            PERIPHERAL_REQUEST_ERROR: 'PERIPHERAL_REQUEST_ERROR'
+        }
+    };
+    const stage = {
+        variables: {},
+        getCustomVars: () => [],
+        lookupVariableById: id => stage.variables[id] || {id: id, name: 'var1', value: 0, type: Variable.SCALAR_TYPE},
+        lookupVariableByNameAndType: () => null,
+        lookupOrCreateVariable: () => ({}),
+        createVariable: () => {},
+        setVariableValue: () => {},
+        renameVariable: () => {}
+    };
+    runtime.getTargetForStage = () => stage;
+    return runtime;
+};
+
+test('Mesh V2 Issue #66: Improved error handling for expired groups', t => {
+    // Set up global window for utils
+    global.window = {
+        location: {
+            search: '?mesh=test-domain'
+        }
+    };
+    global.URLSearchParams = URLSearchParams;
+
+    t.test('connect to expired group (client-side validation)', st => {
+        const mockRuntime = createMockRuntime();
+        const blocks = new MeshV2Blocks(mockRuntime);
+        const now = Date.now();
+        
+        // Mock a group that just expired
+        const expiredGroup = {
+            id: 'expired-id',
+            name: 'Expired Group',
+            domain: 'test-domain',
+            expiresAt: new Date(now - 1000).toISOString()
+        };
+        blocks.discoveredGroups = [expiredGroup];
+
+        blocks.connect('expired-id');
+
+        st.equal(blocks.connectionState, 'error');
+        st.equal(mockRuntime.lastEmittedEvent, 'PERIPHERAL_REQUEST_ERROR');
+        st.deepEqual(mockRuntime.lastEmittedData, {extensionId: 'meshV2'});
+        st.end();
+    });
+
+    t.test('disconnect when group expires during operation', st => {
+        const mockRuntime = createMockRuntime();
+        const blocks = new MeshV2Blocks(mockRuntime);
+        
+        // Simulate being connected
+        blocks.connectionState = 'connected';
+        blocks.meshService.groupId = 'active-group';
+
+        // Trigger disconnect callback with 'GroupNotFound' reason (expired)
+        blocks.meshService.disconnectCallback('GroupNotFound');
+
+        st.equal(blocks.connectionState, 'error');
+        st.equal(mockRuntime.lastEmittedEvent, 'PERIPHERAL_REQUEST_ERROR');
+        st.end();
+    });
+
+    t.test('disconnect when unauthorized', st => {
+        const mockRuntime = createMockRuntime();
+        const blocks = new MeshV2Blocks(mockRuntime);
+        
+        // Simulate being connected
+        blocks.connectionState = 'connected';
+        blocks.meshService.groupId = 'active-group';
+
+        // Trigger disconnect callback with 'Unauthorized' reason
+        blocks.meshService.disconnectCallback('Unauthorized');
+
+        st.equal(blocks.connectionState, 'disconnected'); // Only GroupNotFound/expired currently map to error
+        st.equal(mockRuntime.lastEmittedEvent, 'PERIPHERAL_DISCONNECTED');
+        st.end();
+    });
+
+    t.test('meshService.shouldDisconnectOnError returns reason', st => {
+        const mockRuntime = createMockRuntime();
+        const blocks = new MeshV2Blocks(mockRuntime);
+
+        const error = {
+            graphQLErrors: [{
+                errorType: 'GroupNotFound'
+            }]
+        };
+
+        const reason = blocks.meshService.shouldDisconnectOnError(error);
+        st.equal(reason, 'GroupNotFound');
+        st.end();
+    });
+
+    t.test('meshService.cleanupAndDisconnect passes reason to callback', st => {
+        const mockRuntime = createMockRuntime();
+        const blocks = new MeshV2Blocks(mockRuntime);
+        
+        let capturedReason = null;
+        blocks.meshService.setDisconnectCallback(reason => {
+            capturedReason = reason;
+        });
+
+        blocks.meshService.cleanupAndDisconnect('test-reason');
+        st.equal(capturedReason, 'test-reason');
+        st.end();
+    });
+
+    t.end();
+});


### PR DESCRIPTION
## Summary
When a member attempts to join an expired Mesh V2 group, the connection now properly transitions to an error state instead of briefly showing success and then silently disconnecting.

## Changes
- **Client-side Validation**: Added a check in `connect()` to prevent joining groups that have already expired based on their `expiresAt` timestamp.
- **Disconnect Reasons**: Updated `MeshV2Service` to pass error types (e.g., `GroupNotFound`, `Unauthorized`) as reasons to the disconnect callback.
- **Improved Error UI**: The extension now sets its connection state to `error` when a group expires during operation or when a join attempt fails due to expiration.
- **Data Capture**: Captured `expiresAt` from `joinGroup` response to prepare for future backend support.
- **Tests**: Added a new unit test file `test/unit/extension_mesh_v2_issue66.js` covering these scenarios and updated existing tests to match the new API.

Fixes #66