### PR TITLE
feat: implement MESH v2 load testing scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ npm-*
 
 # Localization
 /translations
+
+# Load Test
+/test/load-test/node_modules

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ npm run coverage
 ```
 
 ## Load Testing (MESH v2)
+
 To run the load testing scripts for MESH v2, you need to install separate dependencies in the `test/load-test` directory:
 
 ```bash
@@ -112,23 +113,39 @@ cd test/load-test
 npm install
 ```
 
-Then you can run the scenarios:
+Set environment variables:
 
 ```bash
-# Data update load test
-node mesh-v2-data-update-load.js
-
-# Event notification load test
-node mesh-v2-event-load.js
-
-# Multi-group load test
-node mesh-v2-multi-group-load.js
-
-# Generate report from the latest results
-node mesh-v2-load-report.js
+export MESH_GRAPHQL_ENDPOINT="https://your-appsync-endpoint.amazonaws.com/graphql"
+export MESH_API_KEY="your-api-key"
 ```
 
+Run the tests using npm scripts:
+
+```bash
+# Data update load test (4 nodes, 4 updates/sec/node, 1 minute)
+npm run test:data-update
+
+# Event notification load test (4 nodes, 4 events/sec/node, 1 minute)
+npm run test:event
+
+# Multi-group load test (2 groups by default)
+npm run test:multi-group
+
+# Multi-group with custom group count
+npm run test:multi-group -- --groups=10
+
+# Run all tests
+npm run test:all
+
+# Generate report from results
+npm run report -- --input=results.json
+```
+
+For detailed documentation, see [test/load-test/README.md](test/load-test/README.md).
+
 ## Publishing to GitHub Pages
+
 ```bash
 npm run deploy
 ```
@@ -136,9 +153,11 @@ npm run deploy
 This will push the currently built playground to the gh-pages branch of the
 currently tracked remote.  If you would like to change where to push to, add
 a repo url argument:
+
 ```bash
 npm run deploy -- -r <your repo url>
 ```
 
 ## Donate
+
 We provide [Scratch](https://scratch.mit.edu) free of charge, and want to keep it that way! Please consider making a [donation](https://secure.donationpay.org/scratchfoundation/) to support our continued engineering, design, community, and resource development efforts. Donations of any size are appreciated. Thank you!

--- a/README.md
+++ b/README.md
@@ -104,6 +104,30 @@ npm test
 npm run coverage
 ```
 
+## Load Testing (MESH v2)
+To run the load testing scripts for MESH v2, you need to install separate dependencies in the `test/load-test` directory:
+
+```bash
+cd test/load-test
+npm install
+```
+
+Then you can run the scenarios:
+
+```bash
+# Data update load test
+node mesh-v2-data-update-load.js
+
+# Event notification load test
+node mesh-v2-event-load.js
+
+# Multi-group load test
+node mesh-v2-multi-group-load.js
+
+# Generate report from the latest results
+node mesh-v2-load-report.js
+```
+
 ## Publishing to GitHub Pages
 ```bash
 npm run deploy

--- a/README.md
+++ b/README.md
@@ -106,43 +106,7 @@ npm run coverage
 
 ## Load Testing (MESH v2)
 
-To run the load testing scripts for MESH v2, you need to install separate dependencies in the `test/load-test` directory:
-
-```bash
-cd test/load-test
-npm install
-```
-
-Set environment variables:
-
-```bash
-export MESH_GRAPHQL_ENDPOINT="https://your-appsync-endpoint.amazonaws.com/graphql"
-export MESH_API_KEY="your-api-key"
-```
-
-Run the tests using npm scripts:
-
-```bash
-# Data update load test (4 nodes, 4 updates/sec/node, 1 minute)
-npm run test:data-update
-
-# Event notification load test (4 nodes, 4 events/sec/node, 1 minute)
-npm run test:event
-
-# Multi-group load test (2 groups by default)
-npm run test:multi-group
-
-# Multi-group with custom group count
-npm run test:multi-group -- --groups=10
-
-# Run all tests
-npm run test:all
-
-# Generate report from results
-npm run report -- --input=results.json
-```
-
-For detailed documentation, see [test/load-test/README.md](test/load-test/README.md).
+Load tests are located in `test/load-test`. For setup and how to run tests, see [test/load-test/README.md](test/load-test/README.md).
 
 ## Publishing to GitHub Pages
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,8 @@
         "tap": "16.3.10",
         "webpack": "5.99.7",
         "webpack-cli": "4.10.0",
-        "webpack-dev-server": "3.11.3"
+        "webpack-dev-server": "3.11.3",
+        "ws": "^8.18.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -7147,6 +7148,21 @@
         "apollo-link": "^1.2.5"
       }
     },
+    "node_modules/apollo-link-context/node_modules/apollo-link": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
+      "license": "MIT",
+      "dependencies": {
+        "apollo-utilities": "^1.3.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "^0.8.21"
+      },
+      "peerDependencies": {
+        "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
     "node_modules/apollo-link-dedup": {
       "version": "1.0.21",
       "resolved": "https://registry.npmjs.org/apollo-link-dedup/-/apollo-link-dedup-1.0.21.tgz",
@@ -7229,6 +7245,21 @@
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
       "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==",
       "license": "MIT"
+    },
+    "node_modules/apollo-link-retry/node_modules/apollo-link": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
+      "license": "MIT",
+      "dependencies": {
+        "apollo-utilities": "^1.3.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "^0.8.21"
+      },
+      "peerDependencies": {
+        "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
     },
     "node_modules/apollo-utilities": {
       "version": "1.3.4",
@@ -7623,7 +7654,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -9685,9 +9717,9 @@
       }
     },
     "node_modules/css-loader/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -15080,6 +15112,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/inquirer/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
     "node_modules/inquirer/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -16360,27 +16405,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/jsdom/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -17610,9 +17634,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -21750,9 +21774,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.41",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
-      "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "dev": true,
       "funding": [
         {
@@ -21771,9 +21795,9 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.0.1",
-        "source-map-js": "^1.2.0"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -21908,9 +21932,9 @@
       }
     },
     "node_modules/postcss-loader/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -21936,15 +21960,15 @@
       }
     },
     "node_modules/postcss-modules-local-by-default": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.5.tgz",
-      "integrity": "sha512-6MieY7sIfTK0hYfafw1OMEG+2bg8Q1ocHCpoWLqOKj3JXlKu4G7btkmM/B7lFubYkYWmRSPLZi5chid63ZaZYw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.2.0.tgz",
+      "integrity": "sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "icss-utils": "^5.0.0",
-        "postcss-selector-parser": "^6.0.2",
+        "postcss-selector-parser": "^7.0.0",
         "postcss-value-parser": "^4.1.0"
       },
       "engines": {
@@ -21955,14 +21979,14 @@
       }
     },
     "node_modules/postcss-modules-scope": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.0.tgz",
-      "integrity": "sha512-oq+g1ssrsZOsx9M96c5w8laRmvEu9C3adDSjI8oTcbfkrTE8hx/zfyobUoWIxaKPO8bt6S62kxpw5GqypEw1QQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
+      "integrity": "sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==",
       "dev": true,
       "license": "ISC",
       "peer": true,
       "dependencies": {
-        "postcss-selector-parser": "^6.0.4"
+        "postcss-selector-parser": "^7.0.0"
       },
       "engines": {
         "node": "^10 || ^12 || >= 14"
@@ -21989,9 +22013,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.1.tgz",
-      "integrity": "sha512-b4dlw/9V8A71rLIDsSwVmak9z2DuBUB7CA1/wSdelNEzqsjoSPeADTWNO09lpH49Diy3/JIZ2bSPB1dI3LJCHg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -23069,18 +23093,6 @@
       "dev": true,
       "dependencies": {
         "aproba": "^1.1.1"
-      }
-    },
-    "node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
       }
     },
     "node_modules/safe-array-concat": {
@@ -24837,9 +24849,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -28325,9 +28337,9 @@
       }
     },
     "node_modules/ts-loader": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.2.tgz",
-      "integrity": "sha512-Qo4piXvOTWcMGIgRiuFa6nHNm+54HbYaZCKqc9eeZCLRy3XqafQgwX2F7mofrbJG3g7EEb+lkiR+z2Lic2s3Zw==",
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.4.tgz",
+      "integrity": "sha512-nCz0rEwunlTZiy6rXFByQU1kVVpCIgUpc/psFiKVrUwrizdnIbRFu8w7bxhUF0X613DYwT4XzrZHpVyMe758hQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -28415,9 +28427,9 @@
       }
     },
     "node_modules/ts-loader/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -28429,14 +28441,14 @@
       }
     },
     "node_modules/ts-loader/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
       "engines": {
-        "node": ">= 8"
+        "node": ">= 12"
       }
     },
     "node_modules/ts-loader/node_modules/supports-color": {
@@ -29986,6 +29998,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/webpack-dev-server/node_modules/ws": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
+      }
+    },
     "node_modules/webpack-dev-server/node_modules/y18n": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
@@ -30353,12 +30375,24 @@
       }
     },
     "node_modules/ws": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
-      "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
-      "dev": true,
-      "dependencies": {
-        "async-limiter": "~1.0.0"
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "tap": "16.3.10",
     "webpack": "5.99.7",
     "webpack-cli": "4.10.0",
-    "webpack-dev-server": "3.11.3",
-    "ws": "^8.18.3"
+    "webpack-dev-server": "3.11.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "tap": "16.3.10",
     "webpack": "5.99.7",
     "webpack-cli": "4.10.0",
-    "webpack-dev-server": "3.11.3"
+    "webpack-dev-server": "3.11.3",
+    "ws": "^8.18.3"
   }
 }

--- a/test/load-test/README.md
+++ b/test/load-test/README.md
@@ -1,0 +1,183 @@
+# MESH v2 Load Testing
+
+Load testing scripts for the MESH v2 GraphQL/AppSync backend.
+
+## Setup
+
+```bash
+cd test/load-test
+npm install
+```
+
+## Environment Variables
+
+Set the following environment variables before running tests:
+
+```bash
+export MESH_GRAPHQL_ENDPOINT="https://your-appsync-endpoint.amazonaws.com/graphql"
+export MESH_API_KEY="your-api-key"
+
+# Alternative variable names (also supported)
+export APPSYNC_ENDPOINT="https://your-appsync-endpoint.amazonaws.com/graphql"
+export APPSYNC_API_KEY="your-api-key"
+```
+
+## Running Tests
+
+### Individual Tests
+
+```bash
+# Data update load test (4 nodes, 4 updates/sec/node, 1 minute)
+npm run test:data-update
+
+# Event notification load test (4 nodes, 4 events/sec/node, 1 minute)
+npm run test:event
+
+# Multi-group load test (2 groups by default)
+npm run test:multi-group
+
+# Multi-group with custom group count
+npm run test:multi-group -- --groups=10
+```
+
+### Run All Tests
+
+```bash
+npm run test:all
+```
+
+## Test Descriptions
+
+### 1. Data Update Load Test (`mesh-v2-data-update-load.js`)
+
+Tests the performance of data update operations:
+
+- Creates a single group with 4 nodes
+- Each node sends data updates at 4 updates/second
+- Runs for 1 minute
+- Measures TPS, latency (P50, P95, P99), and error rates
+
+**Expected Results**: ~16 TPS (4 nodes × 4 updates/sec)
+
+### 2. Event Notification Load Test (`mesh-v2-event-load.js`)
+
+Tests event publishing and delivery performance:
+
+- Creates a single group with 4 nodes
+- Each node publishes events at 4 events/second
+- Runs for 1 minute
+- Measures event delivery delay and error rates
+
+**Expected Results**: ~16 TPS (4 nodes × 4 events/sec)
+
+### 3. Multi-Group Load Test (`mesh-v2-multi-group-load.js`)
+
+Tests concurrent group operations:
+
+- Creates multiple groups (default: 2, configurable with `--groups=N`)
+- Each group has 4 nodes
+- Each node sends 2 data updates/sec + 2 events/sec
+- Runs for 1 minute
+- Detects crosstalk between groups
+
+**Expected Results**: ~32 TPS for 2 groups (8 nodes × 4 ops/sec)
+
+## Test Results
+
+Results are output to console in JSON format and include:
+
+- **Summary**: Duration, total requests, success/error counts, TPS
+- **Latency**: Average, P50, P95, P99, Max (in milliseconds)
+- **Events**: Delivered count, average delivery delay
+- **Crosstalk**: Detection of messages crossing between groups
+
+### Example Output
+
+```json
+{
+  "summary": {
+    "durationSeconds": 61.28,
+    "totalRequests": 959,
+    "successCount": 959,
+    "errorCount": 0,
+    "errorRate": "0.00%",
+    "tps": "15.65"
+  },
+  "latency": {
+    "avg": "109.36",
+    "p50": 106,
+    "p95": 163,
+    "p99": 193,
+    "max": 374
+  },
+  "events": {
+    "delivered": 0,
+    "avgDeliveryDelay": 0
+  },
+  "crosstalk": {
+    "count": 0,
+    "details": []
+  }
+}
+```
+
+## Performance Targets
+
+Based on [GitHub Issue #68](https://github.com/smalruby/scratch-vm/issues/68):
+
+- **Target**: 100 groups × 4 nodes = 400 total nodes
+- **Operations**: 4 data updates/sec + 4 events/sec per node
+- **Expected TPS**: 3,200 TPS (400 nodes × 8 ops/sec)
+- **Platform**: MacBook Air M3 32GB RAM
+
+## Architecture
+
+### Group Lifecycle
+
+1. **Create**: First client (host) creates group with `maxConnectionTimeSeconds=600`
+2. **Heartbeat**: Host sends initial heartbeat to keep group alive
+3. **Join**: Remaining clients join the group
+4. **Subscribe**: All clients subscribe to data updates and events
+5. **Test**: Clients send data updates and publish events
+6. **Cleanup**: Members leave group, host dissolves group
+
+### Key Features
+
+- **Unique identifiers**: Group names and domains use timestamps for uniqueness
+- **Heartbeat management**: Automatic heartbeat sending by hosts
+- **Proper cleanup**: dissolveGroup for hosts, leaveGroup for members
+- **Error handling**: Comprehensive error logging and null-checking
+- **Metrics collection**: TPS, latency percentiles, event delivery tracking
+
+## Troubleshooting
+
+### Error: "maxConnectionTimeSeconds cannot exceed 600"
+
+The server limits group lifetime to 10 minutes (600 seconds). This is the maximum value.
+
+### Error: "Group not found (heartbeat expired)"
+
+Groups require periodic heartbeats. The implementation automatically sends an initial heartbeat after group creation.
+
+### Error: "Group not found" with old UUID
+
+If tests are reusing the same domain name, stale groups may cause conflicts. The tests now use unique domain names per run: `test-domain-${Date.now()}`
+
+## Report Generation
+
+Generate a Markdown report from test results:
+
+```bash
+# Run a test and save output to JSON
+npm run test:data-update > results.json
+
+# Generate report (requires manual JSON extraction from console output)
+npm run report -- --input=results.json
+```
+
+Note: Currently, you need to manually extract the JSON result from console output and save it to a file.
+
+## Related Documentation
+
+- [GitHub Issue #68](https://github.com/smalruby/scratch-vm/issues/68) - Load test implementation
+- [GitHub Issue #454](https://github.com/smalruby/smalruby3-gui/issues/454) - MESH v2 specification

--- a/test/load-test/lib/cloudwatch-integration.js
+++ b/test/load-test/lib/cloudwatch-integration.js
@@ -1,0 +1,62 @@
+const {CloudWatchClient, GetMetricDataCommand} = require('@aws-sdk/client-cloudwatch');
+
+class CloudWatchIntegration {
+    constructor (region = 'ap-northeast-1') {
+        this.client = new CloudWatchClient({region});
+    }
+
+    async getMetrics (startTime, endTime, apiId, tableName) {
+        // This is a template for fetching AppSync and DynamoDB metrics.
+        // In a real scenario, you'd need the specific IDs and names.
+
+        const queries = [];
+
+        if (apiId) {
+            queries.push({
+                Id: 'appsync_latency',
+                MetricStat: {
+                    Metric: {
+                        Namespace: 'AWS/AppSync',
+                        MetricName: 'Latency',
+                        Dimensions: [{Name: 'GraphQLAPIId', Value: apiId}]
+                    },
+                    Period: 60,
+                    Stat: 'Average'
+                }
+            });
+        }
+
+        if (tableName) {
+            queries.push({
+                Id: 'dynamodb_write_capacity',
+                MetricStat: {
+                    Metric: {
+                        Namespace: 'AWS/DynamoDB',
+                        MetricName: 'ConsumedWriteCapacityUnits',
+                        Dimensions: [{Name: 'TableName', Value: tableName}]
+                    },
+                    Period: 60,
+                    Stat: 'Sum'
+                }
+            });
+        }
+
+        if (queries.length === 0) return {};
+
+        const command = new GetMetricDataCommand({
+            StartTime: startTime,
+            EndTime: endTime,
+            MetricDataQueries: queries
+        });
+
+        try {
+            const response = await this.client.send(command);
+            return response.MetricDataResults;
+        } catch (error) {
+            console.error('Failed to fetch CloudWatch metrics:', error);
+            return {};
+        }
+    }
+}
+
+module.exports = {CloudWatchIntegration};

--- a/test/load-test/lib/load-test-metrics.js
+++ b/test/load-test/lib/load-test-metrics.js
@@ -1,0 +1,116 @@
+class LoadTestMetrics {
+    constructor () {
+        this.startTime = Date.now();
+        this.results = {
+            successCount: 0,
+            errorCount: 0,
+            responseTimes: [],
+            errors: [],
+            dataUpdates: 0,
+            eventPublishes: 0,
+            eventDeliveries: [],
+            crosstalk: []
+        };
+    }
+
+    recordSuccess (responseTime) {
+        this.results.successCount++;
+        this.results.responseTimes.push(responseTime);
+    }
+
+    recordError (error, responseTime) {
+        this.results.errorCount++;
+        this.results.responseTimes.push(responseTime);
+        this.results.errors.push({
+            message: error.message,
+            timestamp: Date.now()
+        });
+    }
+
+    recordDataUpdate (groupName, responseTime) {
+        this.results.dataUpdates++;
+        this.recordSuccess(responseTime);
+    }
+
+    recordEventPublish (groupName, responseTime) {
+        this.results.eventPublishes++;
+        this.recordSuccess(responseTime);
+    }
+
+    recordEventDelivery (groupName, delay) {
+        this.results.eventDeliveries.push({
+            groupName,
+            delay,
+            timestamp: Date.now()
+        });
+    }
+
+    recordCrosstalk (type, expectedGroup, actualGroup) {
+        this.results.crosstalk.push({
+            type,
+            expectedGroup,
+            actualGroup,
+            timestamp: Date.now()
+        });
+    }
+
+    getCurrentStats () {
+        const elapsed = (Date.now() - this.startTime) / 1000;
+        const totalReqs = this.results.successCount + this.results.errorCount;
+        const tps = elapsed > 0 ? (totalReqs / elapsed).toFixed(2) : 0;
+
+        return {
+            elapsed: elapsed.toFixed(1),
+            totalRequests: totalReqs,
+            success: this.results.successCount,
+            errors: this.results.errorCount,
+            tps: tps
+        };
+    }
+
+    generateReport () {
+        const sortedTimes = [...this.results.responseTimes].sort((a, b) => a - b);
+        const count = sortedTimes.length;
+
+        const getPercentile = p => {
+            if (count === 0) return 0;
+            const idx = Math.floor((p / 100) * count);
+            return sortedTimes[Math.min(idx, count - 1)];
+        };
+
+        const avg = count > 0 ? sortedTimes.reduce((a, b) => a + b, 0) / count : 0;
+
+        return {
+            summary: {
+                durationSeconds: (Date.now() - this.startTime) / 1000,
+                totalRequests: count + this.results.errorCount,
+                successCount: this.results.successCount,
+                errorCount: this.results.errorCount,
+                errorRate: count + this.results.errorCount > 0 ?
+                    `${(this.results.errorCount / (count + this.results.errorCount) * 100).toFixed(2)}%` :
+                    '0%',
+                tps: ((count + this.results.errorCount) / ((Date.now() - this.startTime) / 1000)).toFixed(2)
+            },
+            latency: {
+                avg: avg.toFixed(2),
+                p50: getPercentile(50),
+                p95: getPercentile(95),
+                p99: getPercentile(99),
+                max: count > 0 ? sortedTimes[count - 1] : 0
+            },
+            events: {
+                delivered: this.results.eventDeliveries.length,
+                avgDeliveryDelay: this.results.eventDeliveries.length > 0 ?
+                    (this.results.eventDeliveries.reduce((a, b) => a + b.delay, 0) /
+                        this.results.eventDeliveries.length).toFixed(2) :
+                    0
+            },
+            crosstalk: {
+                count: this.results.crosstalk.length,
+                details: this.results.crosstalk
+            }
+        };
+    }
+}
+
+module.exports = {LoadTestMetrics};

--- a/test/load-test/lib/mesh-client-simulator.js
+++ b/test/load-test/lib/mesh-client-simulator.js
@@ -1,0 +1,216 @@
+const {ApolloClient, InMemoryCache, HttpLink, split} = require('@apollo/client/core');
+const {GraphQLWsLink} = require('@apollo/client/link/subscriptions');
+const {createClient} = require('graphql-ws');
+const {getMainDefinition} = require('@apollo/client/utilities');
+const ws = require('ws');
+const fetch = require('cross-fetch');
+const {
+    JOIN_GROUP,
+    REPORT_DATA,
+    FIRE_EVENTS,
+    ON_DATA_UPDATE,
+    ON_BATCH_EVENT,
+    SEND_MEMBER_HEARTBEAT
+} = require('../../src/extensions/scratch3_mesh_v2/gql-operations');
+
+class MeshClientSimulator {
+    constructor (options) {
+        this.groupName = options.groupName;
+        this.groupId = options.groupId; // Can be null if joining by name/list
+        const randomId = Math.random().toString(36)
+            .substr(2, 9);
+        this.nodeId = options.nodeName || `node-${randomId}`;
+        this.domain = options.domain || 'localhost';
+        this.appsyncEndpoint = options.appsyncEndpoint;
+        this.apiKey = options.apiKey;
+        this.client = null;
+        this.subscriptions = [];
+        this.onDataUpdateHandler = null;
+        this.onEventHandler = null;
+    }
+
+    async connect () {
+        const httpLink = new HttpLink({
+            uri: this.appsyncEndpoint,
+            headers: {
+                'x-api-key': this.apiKey
+            },
+            fetch
+        });
+
+        // AppSync Realtime WebSocket URL conversion
+        // https://docs.aws.amazon.com/appsync/latest/devguide/realtime-websocket-client.html
+        const wsUrl = this.appsyncEndpoint
+            .replace('https://', 'wss://')
+            .replace('appsync-api', 'appsync-realtime-api');
+
+        const wsLink = new GraphQLWsLink(createClient({
+            url: wsUrl,
+            webSocketImpl: ws,
+            connectionParams: async () => {
+                const header = {
+                    'host': new URL(this.appsyncEndpoint).host,
+                    'x-api-key': this.apiKey
+                };
+                // headerBase64 is used to satisfy AppSync requirements if needed
+                Buffer.from(JSON.stringify(header)).toString('base64')
+                    .replace(/\+/g, '-')
+                    .replace(/\//g, '_')
+                    .replace(/[=]+$/, '');
+                await Promise.resolve();
+                return {
+                    payload: {},
+                    headers: {
+                        'Authorization': this.apiKey,
+                        'x-api-key': this.apiKey
+                    }
+                };
+            }
+        }));
+
+        const link = split(
+            ({query}) => {
+                const definition = getMainDefinition(query);
+                return (
+                    definition.kind === 'OperationDefinition' &&
+                    definition.operation === 'subscription'
+                );
+            },
+            wsLink,
+            httpLink
+        );
+
+        this.client = new ApolloClient({
+            link,
+            cache: new InMemoryCache(),
+            defaultOptions: {
+                watchQuery: {fetchPolicy: 'no-cache'},
+                query: {fetchPolicy: 'no-cache'}
+            }
+        });
+
+        // Join group if groupId is provided
+        if (this.groupId) {
+            await this.join();
+        }
+    }
+
+    async join () {
+        try {
+            const result = await this.client.mutate({
+                mutation: JOIN_GROUP,
+                variables: {
+                    groupId: this.groupId,
+                    domain: this.domain,
+                    nodeId: this.nodeId
+                }
+            });
+            const node = result.data.joinGroup;
+            this.domain = node.domain;
+            return node;
+        } catch (error) {
+            console.error(`Client ${this.nodeId} failed to join group ${this.groupId}:`, error.message);
+            throw error;
+        }
+    }
+
+    async subscribeToEvents () {
+        if (!this.groupId) throw new Error('Not joined to a group');
+
+        const dataSub = this.client.subscribe({
+            query: ON_DATA_UPDATE,
+            variables: {groupId: this.groupId, domain: this.domain}
+        }).subscribe({
+            next: result => {
+                if (this.onDataUpdateHandler) {
+                    this.onDataUpdateHandler(result.data.onDataUpdateInGroup);
+                }
+            },
+            error: err => console.error('Subscription error (data):', err)
+        });
+
+        const eventSub = this.client.subscribe({
+            query: ON_BATCH_EVENT,
+            variables: {groupId: this.groupId, domain: this.domain}
+        }).subscribe({
+            next: result => {
+                if (this.onEventHandler) {
+                    const batch = result.data.onBatchEventInGroup;
+                    batch.events.forEach(event => this.onEventHandler(event));
+                }
+            },
+            error: err => console.error('Subscription error (event):', err)
+        });
+
+        this.subscriptions.push(dataSub, eventSub);
+        await Promise.resolve();
+    }
+
+    onDataUpdate (handler) {
+        this.onDataUpdateHandler = handler;
+    }
+
+    onEvent (handler) {
+        this.onEventHandler = handler;
+    }
+
+    async updateData (data) {
+        // data should be an object, convert to array of {key, value}
+        const dataArray = Object.entries(data).map(([key, value]) => ({
+            key,
+            value: String(value)
+        }));
+
+        await Promise.resolve(); // satisfy require-await
+
+        return this.client.mutate({
+            mutation: REPORT_DATA,
+            variables: {
+                groupId: this.groupId,
+                domain: this.domain,
+                nodeId: this.nodeId,
+                data: dataArray
+            }
+        });
+    }
+
+    async publishEvent (event) {
+        await Promise.resolve(); // satisfy require-await
+        return this.client.mutate({
+            mutation: FIRE_EVENTS,
+            variables: {
+                groupId: this.groupId,
+                domain: this.domain,
+                nodeId: this.nodeId,
+                events: [{
+                    name: event.type,
+                    payload: JSON.stringify(event.data || {}),
+                    timestamp: new Date().toISOString()
+                }]
+            }
+        });
+    }
+
+    async sendHeartbeat () {
+        await Promise.resolve(); // satisfy require-await
+        return this.client.mutate({
+            mutation: SEND_MEMBER_HEARTBEAT,
+            variables: {
+                groupId: this.groupId,
+                domain: this.domain,
+                nodeId: this.nodeId
+            }
+        });
+    }
+
+    async disconnect () {
+        this.subscriptions.forEach(sub => sub.unsubscribe());
+        this.subscriptions = [];
+        if (this.client) {
+            this.client.stop();
+            await Promise.resolve();
+        }
+    }
+}
+
+module.exports = {MeshClientSimulator};

--- a/test/load-test/mesh-v2-data-update-load.js
+++ b/test/load-test/mesh-v2-data-update-load.js
@@ -1,0 +1,126 @@
+const {MeshClientSimulator} = require('./lib/mesh-client-simulator');
+const {LoadTestMetrics} = require('./lib/load-test-metrics');
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Run Data Update Load Test.
+ * @param {object} config - Test configuration.
+ * @returns {Promise<object>} - Test results.
+ */
+const runDataUpdateLoadTest = async function (config) {
+    const {
+        groupCount = 1,
+        nodesPerGroup = 4,
+        updatesPerSecondPerNode = 4,
+        durationMinutes = 5,
+        groupId = 'load-test-group-default'
+    } = config;
+
+    const clients = [];
+    const metrics = new LoadTestMetrics();
+
+    console.log(`Setting up ${groupCount * nodesPerGroup} clients...`);
+    for (let g = 0; g < groupCount; g++) {
+        const currentGroupId = groupId + (groupCount > 1 ? `-${g}` : '');
+        for (let n = 0; n < nodesPerGroup; n++) {
+            const client = new MeshClientSimulator({
+                groupId: currentGroupId,
+                nodeName: `node-${g}-${n}`,
+                appsyncEndpoint: process.env.MESH_GRAPHQL_ENDPOINT || process.env.APPSYNC_ENDPOINT,
+                apiKey: process.env.MESH_API_KEY || process.env.APPSYNC_API_KEY,
+                domain: 'load-test'
+            });
+            clients.push(client);
+        }
+    }
+
+    console.log('Connecting clients...');
+    // Connect in batches to avoid overwhelming the local machine/network
+    const batchSize = 10;
+    for (let i = 0; i < clients.length; i += batchSize) {
+        const batch = clients.slice(i, i + batchSize);
+        await Promise.all(batch.map(c => c.connect()));
+        if (i + batchSize < clients.length) await sleep(100);
+    }
+
+    console.log('Starting load test...');
+    const startTime = Date.now();
+    const endTime = startTime + (durationMinutes * 60 * 1000);
+    const updateInterval = 1000 / updatesPerSecondPerNode;
+
+    /**
+     * Run Client Updates.
+     * @param {object} client - MeshClientSimulator instance.
+     * @param {number} intervalMs - Interval between updates.
+     * @param {number} clientEndTime - End time for the test.
+     * @param {object} clientMetrics - LoadTestMetrics instance.
+     * @returns {Promise<void>} - Completion.
+     */
+    const runClientUpdates = async function (client, intervalMs, clientEndTime, clientMetrics) {
+        while (Date.now() < clientEndTime) {
+            const clientStartTime = Date.now();
+            try {
+                await client.updateData({
+                    load_test_value: Math.random(),
+                    timestamp: Date.now()
+                });
+                const responseTime = Date.now() - clientStartTime;
+                clientMetrics.recordDataUpdate(client.groupId, responseTime);
+            } catch (error) {
+                const responseTime = Date.now() - clientStartTime;
+                clientMetrics.recordError(error, responseTime);
+            }
+
+            const elapsed = Date.now() - clientStartTime;
+            const waitTime = Math.max(0, intervalMs - elapsed);
+            await sleep(waitTime);
+        }
+    };
+
+    const updatePromises = clients.map(client => runClientUpdates(client, updateInterval, endTime, metrics));
+
+    // Progress reporting
+    const progressInterval = setInterval(() => {
+        console.log(JSON.stringify(metrics.getCurrentStats()));
+    }, 5000);
+
+    await Promise.all(updatePromises);
+    clearInterval(progressInterval);
+
+    console.log('Disconnecting clients...');
+    for (let i = 0; i < clients.length; i += batchSize) {
+        const batch = clients.slice(i, i + batchSize);
+        await Promise.all(batch.map(c => c.disconnect()));
+    }
+
+    return metrics.generateReport();
+};
+
+/**
+ * Main function.
+ * @returns {Promise<void>} - Completion.
+ */
+const main = async function () {
+    console.log('=== MESH v2 データ更新負荷テスト ===\n');
+
+    if (!process.env.MESH_GRAPHQL_ENDPOINT && !process.env.APPSYNC_ENDPOINT) {
+        console.error('Error: MESH_GRAPHQL_ENDPOINT or APPSYNC_ENDPOINT environment variable is required.');
+        process.exit(1);
+    }
+
+    // 1.1 基本負荷テスト
+    console.log('1.1 基本負荷テスト (4ノード、4回/秒/ノード、1分間)');
+    const basicResult = await runDataUpdateLoadTest({
+        groupCount: 1,
+        nodesPerGroup: 4,
+        updatesPerSecondPerNode: 4,
+        durationMinutes: 1,
+        groupId: `basic-test-${Date.now()}`
+    });
+    console.log('結果:', JSON.stringify(basicResult, null, 2));
+};
+
+if (require.main === module) {
+    main().catch(console.error);
+}

--- a/test/load-test/mesh-v2-event-load.js
+++ b/test/load-test/mesh-v2-event-load.js
@@ -1,0 +1,138 @@
+const {MeshClientSimulator} = require('./lib/mesh-client-simulator');
+const {LoadTestMetrics} = require('./lib/load-test-metrics');
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Run Event Load Test.
+ * @param {object} config - Test configuration.
+ * @returns {Promise<object>} - Test results.
+ */
+const runEventLoadTest = async function (config) {
+    const {
+        groupCount = 1,
+        nodesPerGroup = 4,
+        eventsPerSecondPerNode = 4,
+        durationMinutes = 5,
+        groupId = 'event-load-test'
+    } = config;
+
+    const metrics = new LoadTestMetrics();
+    const groups = [];
+
+    console.log(`Setting up ${groupCount} groups with ${nodesPerGroup} nodes each...`);
+    for (let g = 0; g < groupCount; g++) {
+        const currentGroupId = `${groupId}-${Date.now()}-${g}`;
+        const clients = [];
+        for (let n = 0; n < nodesPerGroup; n++) {
+            const client = new MeshClientSimulator({
+                groupId: currentGroupId,
+                nodeName: `node-${g}-${n}`,
+                appsyncEndpoint: process.env.MESH_GRAPHQL_ENDPOINT || process.env.APPSYNC_ENDPOINT,
+                apiKey: process.env.MESH_API_KEY || process.env.APPSYNC_API_KEY,
+                domain: 'load-test'
+            });
+
+            client.onEvent(event => {
+                const payload = JSON.parse(event.payload);
+                if (payload.sentAt) {
+                    const delay = Date.now() - payload.sentAt;
+                    metrics.recordEventDelivery(currentGroupId, delay);
+                }
+            });
+
+            clients.push(client);
+        }
+        groups.push({groupId: currentGroupId, clients});
+    }
+
+    console.log('Connecting clients and subscribing to events...');
+    for (const group of groups) {
+        await Promise.all(group.clients.map(c => c.connect()));
+        await Promise.all(group.clients.map(c => c.subscribeToEvents()));
+        await sleep(100);
+    }
+
+    console.log('Starting event load test...');
+    const startTime = Date.now();
+    const endTime = startTime + (durationMinutes * 60 * 1000);
+
+    /**
+     * Run Client Events.
+     * @param {object} client - MeshClientSimulator instance.
+     * @param {number} ratePerSecond - Rate of event publishing.
+     * @param {number} clientEndTime - End time for the test.
+     * @param {object} clientMetrics - LoadTestMetrics instance.
+     * @returns {Promise<void>} - Completion.
+     */
+    const runClientEvents = async function (client, ratePerSecond, clientEndTime, clientMetrics) {
+        const intervalMs = 1000 / ratePerSecond;
+        while (Date.now() < clientEndTime) {
+            const clientStartTime = Date.now();
+            try {
+                await client.publishEvent({
+                    type: 'load-test-event',
+                    data: {
+                        sentAt: Date.now(),
+                        value: Math.random()
+                    }
+                });
+                const responseTime = Date.now() - clientStartTime;
+                clientMetrics.recordEventPublish(client.groupId, responseTime);
+            } catch (error) {
+                const responseTime = Date.now() - clientStartTime;
+                clientMetrics.recordError(error, responseTime);
+            }
+
+            const elapsed = Date.now() - clientStartTime;
+            await sleep(Math.max(0, intervalMs - elapsed));
+        }
+    };
+
+    const publishPromises = [];
+    for (const group of groups) {
+        for (const client of group.clients) {
+            publishPromises.push(runClientEvents(client, eventsPerSecondPerNode, endTime, metrics));
+        }
+    }
+
+    const progressInterval = setInterval(() => {
+        console.log(JSON.stringify(metrics.getCurrentStats()));
+    }, 5000);
+
+    await Promise.all(publishPromises);
+    clearInterval(progressInterval);
+
+    console.log('Disconnecting clients...');
+    for (const group of groups) {
+        await Promise.all(group.clients.map(c => c.disconnect()));
+    }
+
+    return metrics.generateReport();
+};
+
+/**
+ * Main function.
+ * @returns {Promise<void>} - Completion.
+ */
+const main = async function () {
+    console.log('=== MESH v2 イベント通知負荷テスト ===\n');
+
+    if (!process.env.MESH_GRAPHQL_ENDPOINT && !process.env.APPSYNC_ENDPOINT) {
+        console.error('Error: MESH_GRAPHQL_ENDPOINT or APPSYNC_ENDPOINT environment variable is required.');
+        process.exit(1);
+    }
+
+    console.log('2.1 基本イベント配信テスト (4ノード、4回/秒/ノード、1分間)');
+    const result = await runEventLoadTest({
+        groupCount: 1,
+        nodesPerGroup: 4,
+        eventsPerSecondPerNode: 4,
+        durationMinutes: 1
+    });
+    console.log('結果:', JSON.stringify(result, null, 2));
+};
+
+if (require.main === module) {
+    main().catch(console.error);
+}

--- a/test/load-test/mesh-v2-load-report.js
+++ b/test/load-test/mesh-v2-load-report.js
@@ -1,0 +1,76 @@
+const fs = require('fs');
+
+/**
+ * Generate report.
+ * @param {string} inputPath - Path to results JSON file.
+ * @param {string} outputPath - Path to output Markdown file.
+ * @returns {Promise<void>} - Completion.
+ */
+const generateReport = async function (inputPath, outputPath) {
+    if (!fs.existsSync(inputPath)) {
+        console.error(`Input file not found: ${inputPath}`);
+        return;
+    }
+
+    const data = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+
+    // For now, we'll just generate a Markdown report as a placeholder for the HTML/Chart.js report.
+    // The user can extend this to generate HTML.
+
+    const report = `
+# MESH v2 負荷テストレポート
+生成日時: ${new Date().toLocaleString()}
+
+## サマリー
+- テスト期間: ${data.summary.durationSeconds.toFixed(1)} 秒
+- 総リクエスト数: ${data.summary.totalRequests}
+- 成功数: ${data.summary.successCount}
+- エラー数: ${data.summary.errorCount}
+- エラー率: ${data.summary.errorRate}
+- スループット: ${data.summary.tps} TPS
+
+## レテンシ (ms)
+- 平均: ${data.latency.avg}
+- P50: ${data.latency.p50}
+- P95: ${data.latency.p95}
+- P99: ${data.latency.p99}
+- 最大: ${data.latency.max}
+
+## イベント配信
+- 配信済み数: ${data.events.delivered}
+- 平均配信遅延: ${data.events.avgDeliveryDelay} ms
+
+## クロストーク
+- 検出数: ${data.crosstalk.count}
+${data.crosstalk.count > 0 ? `
+### 詳細
+${JSON.stringify(data.crosstalk.details, null, 2)}` : ''}
+`;
+
+    fs.writeFileSync(outputPath, report);
+    console.log(`Report generated: ${outputPath}`);
+
+    await Promise.resolve(); // satisfy require-await
+};
+
+/**
+ * Main function.
+ * @returns {Promise<void>} - Completion.
+ */
+const main = async function () {
+    const args = process.argv.slice(2);
+    const inputArg = args.find(a => a.startsWith('--input='));
+    const inputPath = inputArg ? inputArg.split('=')[1] : null;
+
+    if (!inputPath) {
+        console.error('Usage: node mesh-v2-load-report.js --input=results.json');
+        process.exit(1);
+    }
+
+    const outputPath = inputPath.replace('.json', '.md');
+    await generateReport(inputPath, outputPath);
+};
+
+if (require.main === module) {
+    main().catch(console.error);
+}

--- a/test/load-test/mesh-v2-multi-group-load.js
+++ b/test/load-test/mesh-v2-multi-group-load.js
@@ -1,0 +1,177 @@
+const {MeshClientSimulator} = require('./lib/mesh-client-simulator');
+const {LoadTestMetrics} = require('./lib/load-test-metrics');
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Run Multi-Group Load Test.
+ * @param {object} config - Test configuration.
+ * @returns {Promise<object>} - Test results.
+ */
+const runMultiGroupLoadTest = async function (config) {
+    const {
+        groupCount = 10,
+        nodesPerGroup = 4,
+        dataUpdatesPerSecond = 2,
+        eventsPerSecond = 2,
+        durationMinutes = 5,
+        groupIdPrefix = 'multi-group-test'
+    } = config;
+
+    const metrics = new LoadTestMetrics();
+    const groups = [];
+
+    console.log('=== 複数グループ負荷テスト ===');
+    console.log(`グループ数: ${groupCount}`);
+    console.log(`ノード/グループ: ${nodesPerGroup}`);
+    console.log(`合計ノード数: ${groupCount * nodesPerGroup}`);
+    console.log(`目標TPS: ${groupCount * nodesPerGroup * (dataUpdatesPerSecond + eventsPerSecond)}`);
+
+    for (let g = 0; g < groupCount; g++) {
+        const groupId = `${groupIdPrefix}-${Date.now()}-${g}`;
+        const clients = [];
+        for (let n = 0; n < nodesPerGroup; n++) {
+            const client = new MeshClientSimulator({
+                groupId: groupId,
+                nodeName: `node-${g}-${n}`,
+                appsyncEndpoint: process.env.MESH_GRAPHQL_ENDPOINT || process.env.APPSYNC_ENDPOINT,
+                apiKey: process.env.MESH_API_KEY || process.env.APPSYNC_API_KEY,
+                domain: 'load-test'
+            });
+
+            client.onDataUpdate(data => {
+                if (data.groupId !== groupId) {
+                    metrics.recordCrosstalk('data', groupId, data.groupId);
+                }
+            });
+
+            client.onEvent(event => {
+                if (event.groupId !== groupId) {
+                    metrics.recordCrosstalk('event', groupId, event.groupId);
+                }
+            });
+
+            clients.push(client);
+        }
+        groups.push({groupId, clients});
+    }
+
+    console.log('クライアント接続中...');
+    const batchSize = 20;
+    const allClients = groups.flatMap(g => g.clients);
+    for (let i = 0; i < allClients.length; i += batchSize) {
+        const batch = allClients.slice(i, i + batchSize);
+        await Promise.all(batch.map(c => c.connect()));
+        await Promise.all(batch.map(c => c.subscribeToEvents()));
+        console.log(`${Math.min(i + batchSize, allClients.length)}/${allClients.length} クライアント接続・サブスクライブ完了`);
+        await sleep(200);
+    }
+
+    console.log('負荷テスト開始...');
+    const startTime = Date.now();
+    const endTime = startTime + (durationMinutes * 60 * 1000);
+
+    /**
+     * Run Data Update Workload.
+     * @param {object} client - MeshClientSimulator instance.
+     * @param {number} ratePerSecond - Rate of data updates.
+     * @param {number} clientEndTime - End time for the test.
+     * @param {object} clientMetrics - LoadTestMetrics instance.
+     * @returns {Promise<void>} - Completion.
+     */
+    const runDataUpdateWorkload = async function (client, ratePerSecond, clientEndTime, clientMetrics) {
+        const intervalMs = 1000 / ratePerSecond;
+        while (Date.now() < clientEndTime) {
+            const clientStartTime = Date.now();
+            try {
+                await client.updateData({
+                    timestamp: Date.now(),
+                    value: Math.random()
+                });
+                clientMetrics.recordDataUpdate(client.groupId, Date.now() - clientStartTime);
+            } catch (error) {
+                clientMetrics.recordError(error, Date.now() - clientStartTime);
+            }
+            const elapsed = Date.now() - clientStartTime;
+            await sleep(Math.max(0, intervalMs - elapsed));
+        }
+    };
+
+    /**
+     * Run Event Workload.
+     * @param {object} client - MeshClientSimulator instance.
+     * @param {number} ratePerSecond - Rate of event publishing.
+     * @param {number} clientEndTime - End time for the test.
+     * @param {object} clientMetrics - LoadTestMetrics instance.
+     * @returns {Promise<void>} - Completion.
+     */
+    const runEventWorkload = async function (client, ratePerSecond, clientEndTime, clientMetrics) {
+        const intervalMs = 1000 / ratePerSecond;
+        while (Date.now() < clientEndTime) {
+            const clientStartTime = Date.now();
+            try {
+                await client.publishEvent({
+                    type: 'multi-load-event',
+                    data: {sentAt: Date.now(), val: Math.random()}
+                });
+                clientMetrics.recordEventPublish(client.groupId, Date.now() - clientStartTime);
+            } catch (error) {
+                clientMetrics.recordError(error, Date.now() - clientStartTime);
+            }
+            const elapsed = Date.now() - clientStartTime;
+            await sleep(Math.max(0, intervalMs - elapsed));
+        }
+    };
+
+    const workloadPromises = [];
+    for (const group of groups) {
+        for (const client of group.clients) {
+            workloadPromises.push(runDataUpdateWorkload(client, dataUpdatesPerSecond, endTime, metrics));
+            workloadPromises.push(runEventWorkload(client, eventsPerSecond, endTime, metrics));
+        }
+    }
+
+    const progressInterval = setInterval(() => {
+        console.log(`[${new Date().toISOString()}] Progress: ${JSON.stringify(metrics.getCurrentStats())}`);
+    }, 10000);
+
+    await Promise.all(workloadPromises);
+    clearInterval(progressInterval);
+
+    console.log('クライアント切断中...');
+    for (let i = 0; i < allClients.length; i += batchSize) {
+        const batch = allClients.slice(i, i + batchSize);
+        await Promise.all(batch.map(c => c.disconnect()));
+    }
+
+    return metrics.generateReport();
+};
+
+/**
+ * Main function.
+ * @returns {Promise<void>} - Completion.
+ */
+const main = async function () {
+    const args = process.argv.slice(2);
+    const groupCountArg = args.find(a => a.startsWith('--groups='));
+    const groupCount = groupCountArg ? parseInt(groupCountArg.split('=')[1], 10) : 2;
+
+    if (!process.env.MESH_GRAPHQL_ENDPOINT && !process.env.APPSYNC_ENDPOINT) {
+        console.error('Error: MESH_GRAPHQL_ENDPOINT or APPSYNC_ENDPOINT environment variable is required.');
+        process.exit(1);
+    }
+
+    const result = await runMultiGroupLoadTest({
+        groupCount: groupCount,
+        nodesPerGroup: 4,
+        dataUpdatesPerSecond: 2,
+        eventsPerSecond: 2,
+        durationMinutes: 1
+    });
+
+    console.log('最終結果:', JSON.stringify(result, null, 2));
+};
+
+if (require.main === module) {
+    main().catch(console.error);
+}

--- a/test/load-test/package-lock.json
+++ b/test/load-test/package-lock.json
@@ -1,0 +1,1603 @@
+{
+  "name": "scratch-vm-load-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "scratch-vm-load-test",
+      "version": "1.0.0",
+      "dependencies": {
+        "@apollo/client": "^4.0.11",
+        "@aws-sdk/client-cloudwatch": "^3.958.0",
+        "chart.js": "^4.5.1",
+        "cross-fetch": "^4.1.0",
+        "graphql": "^16.12.0",
+        "graphql-ws": "^6.0.6",
+        "ws": "^8.18.3"
+      }
+    },
+    "node_modules/@apollo/client": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.0.11.tgz",
+      "integrity": "sha512-jyW5j3DEYnFlYA1Lk9Szd7O/od1DptnbZnj03DQXxuQb+Gnop0w/uQxVRKaU7bPhvVuBnlAtZYPOykArX+xWdg==",
+      "license": "MIT",
+      "workspaces": [
+        "dist",
+        "codegen",
+        "scripts/codemods/ac3-to-ac4"
+      ],
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.5.0",
+        "graphql-tag": "^2.12.6",
+        "optimism": "^0.18.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^16.0.0",
+        "graphql-ws": "^5.5.5 || ^6.0.3",
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "react-dom": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "rxjs": "^7.3.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch": {
+      "version": "3.958.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.958.0.tgz",
+      "integrity": "sha512-AiycUy+M0STDoYeXvR/HfnRElsf4zVSx7fAX02ALDAkNGIy9kgLdrkqYRWuP7oYdRWu1qd0fOgzqxvZVdzCNQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/credential-provider-node": "3.958.0",
+        "@aws-sdk/middleware-host-header": "3.957.0",
+        "@aws-sdk/middleware-logger": "3.957.0",
+        "@aws-sdk/middleware-recursion-detection": "3.957.0",
+        "@aws-sdk/middleware-user-agent": "3.957.0",
+        "@aws-sdk/region-config-resolver": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/util-endpoints": "3.957.0",
+        "@aws-sdk/util-user-agent-browser": "3.957.0",
+        "@aws-sdk/util-user-agent-node": "3.957.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/hash-node": "^4.2.7",
+        "@smithy/invalid-dependency": "^4.2.7",
+        "@smithy/middleware-compression": "^4.3.16",
+        "@smithy/middleware-content-length": "^4.2.7",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.16",
+        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.958.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.958.0.tgz",
+      "integrity": "sha512-6qNCIeaMzKzfqasy2nNRuYnMuaMebCcCPP4J2CVGkA8QYMbIVKPlkn9bpB20Vxe6H/r3jtCCLQaOJjVTx/6dXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/middleware-host-header": "3.957.0",
+        "@aws-sdk/middleware-logger": "3.957.0",
+        "@aws-sdk/middleware-recursion-detection": "3.957.0",
+        "@aws-sdk/middleware-user-agent": "3.957.0",
+        "@aws-sdk/region-config-resolver": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/util-endpoints": "3.957.0",
+        "@aws-sdk/util-user-agent-browser": "3.957.0",
+        "@aws-sdk/util-user-agent-node": "3.957.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/hash-node": "^4.2.7",
+        "@smithy/invalid-dependency": "^4.2.7",
+        "@smithy/middleware-content-length": "^4.2.7",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.16",
+        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.957.0.tgz",
+      "integrity": "sha512-DrZgDnF1lQZv75a52nFWs6MExihJF2GZB6ETZRqr6jMwhrk2kbJPUtvgbifwcL7AYmVqHQDJBrR/MqkwwFCpiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/xml-builder": "3.957.0",
+        "@smithy/core": "^3.20.0",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/signature-v4": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.957.0.tgz",
+      "integrity": "sha512-475mkhGaWCr+Z52fOOVb/q2VHuNvqEDixlYIkeaO6xJ6t9qR0wpLt4hOQaR6zR1wfZV0SlE7d8RErdYq/PByog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.957.0.tgz",
+      "integrity": "sha512-8dS55QHRxXgJlHkEYaCGZIhieCs9NU1HU1BcqQ4RfUdSsfRdxxktqUKgCnBnOOn0oD3PPA8cQOCAVgIyRb3Rfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-stream": "^4.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.958.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.958.0.tgz",
+      "integrity": "sha512-u7twvZa1/6GWmPBZs6DbjlegCoNzNjBsMS/6fvh5quByYrcJr/uLd8YEr7S3UIq4kR/gSnHqcae7y2nL2bqZdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/credential-provider-env": "3.957.0",
+        "@aws-sdk/credential-provider-http": "3.957.0",
+        "@aws-sdk/credential-provider-login": "3.958.0",
+        "@aws-sdk/credential-provider-process": "3.957.0",
+        "@aws-sdk/credential-provider-sso": "3.958.0",
+        "@aws-sdk/credential-provider-web-identity": "3.958.0",
+        "@aws-sdk/nested-clients": "3.958.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/credential-provider-imds": "^4.2.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.958.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.958.0.tgz",
+      "integrity": "sha512-sDwtDnBSszUIbzbOORGh5gmXGl9aK25+BHb4gb1aVlqB+nNL2+IUEJA62+CE55lXSH8qXF90paivjK8tOHTwPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/nested-clients": "3.958.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.958.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.958.0.tgz",
+      "integrity": "sha512-vdoZbNG2dt66I7EpN3fKCzi6fp9xjIiwEA/vVVgqO4wXCGw8rKPIdDUus4e13VvTr330uQs2W0UNg/7AgtquEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.957.0",
+        "@aws-sdk/credential-provider-http": "3.957.0",
+        "@aws-sdk/credential-provider-ini": "3.958.0",
+        "@aws-sdk/credential-provider-process": "3.957.0",
+        "@aws-sdk/credential-provider-sso": "3.958.0",
+        "@aws-sdk/credential-provider-web-identity": "3.958.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/credential-provider-imds": "^4.2.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.957.0.tgz",
+      "integrity": "sha512-/KIz9kadwbeLy6SKvT79W81Y+hb/8LMDyeloA2zhouE28hmne+hLn0wNCQXAAupFFlYOAtZR2NTBs7HBAReJlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.958.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.958.0.tgz",
+      "integrity": "sha512-CBYHJ5ufp8HC4q+o7IJejCUctJXWaksgpmoFpXerbjAso7/Fg7LLUu9inXVOxlHKLlvYekDXjIUBXDJS2WYdgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.958.0",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/token-providers": "3.958.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.958.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.958.0.tgz",
+      "integrity": "sha512-dgnvwjMq5Y66WozzUzxNkCFap+umHUtqMMKlr8z/vl9NYMLem/WUbWNpFFOVFWquXikc+ewtpBMR4KEDXfZ+KA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/nested-clients": "3.958.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.957.0.tgz",
+      "integrity": "sha512-BBgKawVyfQZglEkNTuBBdC3azlyqNXsvvN4jPkWAiNYcY0x1BasaJFl+7u/HisfULstryweJq/dAvIZIxzlZaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.957.0.tgz",
+      "integrity": "sha512-w1qfKrSKHf9b5a8O76yQ1t69u6NWuBjr5kBX+jRWFx/5mu6RLpqERXRpVJxfosbep7k3B+DSB5tZMZ82GKcJtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.957.0.tgz",
+      "integrity": "sha512-D2H/WoxhAZNYX+IjkKTdOhOkWQaK0jjJrDBj56hKjU5c9ltQiaX/1PqJ4dfjHntEshJfu0w+E6XJ+/6A6ILBBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.957.0",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.957.0.tgz",
+      "integrity": "sha512-50vcHu96XakQnIvlKJ1UoltrFODjsq2KvtTgHiPFteUS884lQnK5VC/8xd1Msz/1ONpLMzdCVproCQqhDTtMPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/util-endpoints": "3.957.0",
+        "@smithy/core": "^3.20.0",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.958.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.958.0.tgz",
+      "integrity": "sha512-/KuCcS8b5TpQXkYOrPLYytrgxBhv81+5pChkOlhegbeHttjM69pyUpQVJqyfDM/A7wPLnDrzCAnk4zaAOkY0Nw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/middleware-host-header": "3.957.0",
+        "@aws-sdk/middleware-logger": "3.957.0",
+        "@aws-sdk/middleware-recursion-detection": "3.957.0",
+        "@aws-sdk/middleware-user-agent": "3.957.0",
+        "@aws-sdk/region-config-resolver": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/util-endpoints": "3.957.0",
+        "@aws-sdk/util-user-agent-browser": "3.957.0",
+        "@aws-sdk/util-user-agent-node": "3.957.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/hash-node": "^4.2.7",
+        "@smithy/invalid-dependency": "^4.2.7",
+        "@smithy/middleware-content-length": "^4.2.7",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.16",
+        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.957.0.tgz",
+      "integrity": "sha512-V8iY3blh8l2iaOqXWW88HbkY5jDoWjH56jonprG/cpyqqCnprvpMUZWPWYJoI8rHRf2bqzZeql1slxG6EnKI7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.958.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.958.0.tgz",
+      "integrity": "sha512-UCj7lQXODduD1myNJQkV+LYcGYJ9iiMggR8ow8Hva1g3A/Na5imNXzz6O67k7DAee0TYpy+gkNw+SizC6min8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/nested-clients": "3.958.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.957.0.tgz",
+      "integrity": "sha512-wzWC2Nrt859ABk6UCAVY/WYEbAd7FjkdrQL6m24+tfmWYDNRByTJ9uOgU/kw9zqLCAwb//CPvrJdhqjTznWXAg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.957.0.tgz",
+      "integrity": "sha512-xwF9K24mZSxcxKS3UKQFeX/dPYkEps9wF1b+MGON7EvnbcucrJGyQyK1v1xFPn1aqXkBTFi+SZaMRx5E5YCVFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-endpoints": "^3.2.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.957.0.tgz",
+      "integrity": "sha512-nhmgKHnNV9K+i9daumaIz8JTLsIIML9PE/HUks5liyrjUzenjW/aHoc7WJ9/Td/gPZtayxFnXQSJRb/fDlBuJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.957.0.tgz",
+      "integrity": "sha512-exueuwxef0lUJRnGaVkNSC674eAiWU07ORhxBnevFFZEKisln+09Qrtw823iyv5I1N8T+wKfh95xvtWQrNKNQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/types": "^4.11.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.957.0.tgz",
+      "integrity": "sha512-ycbYCwqXk4gJGp0Oxkzf2KBeeGBdTxz559D41NJP8FlzSej1Gh7Rk40Zo6AyTfsNWkrl/kVi1t937OIzC5t+9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.957.0.tgz",
+      "integrity": "sha512-Ai5iiQqS8kJ5PjzMhWcLKN0G2yasAkvpnPlq2EnqlIMdB48HsizElt62qcktdxp4neRMyGkFq4NzgmDbXnhRiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz",
+      "integrity": "sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.7.tgz",
+      "integrity": "sha512-rzMY6CaKx2qxrbYbqjXWS0plqEy7LOdKHS0bg4ixJ6aoGDPNUcLWk/FRNuCILh7GKLG9TFUXYYeQQldMBBwuyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.5.tgz",
+      "integrity": "sha512-HAGoUAFYsUkoSckuKbCPayECeMim8pOu+yLy1zOxt1sifzEbrsRpYa+mKcMdiHKMeiqOibyPG0sFJnmaV/OGEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.20.0.tgz",
+      "integrity": "sha512-WsSHCPq/neD5G/MkK4csLI5Y5Pkd9c1NMfpYEKeghSGaD4Ja1qLIohRQf2D5c1Uy5aXp76DeKHkzWZ9KAlHroQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-stream": "^4.5.8",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.7.tgz",
+      "integrity": "sha512-CmduWdCiILCRNbQWFR0OcZlUPVtyE49Sr8yYL0rZQ4D/wKxiNzBNS/YHemvnbkIWj623fplgkexUd/c9CAKdoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.8.tgz",
+      "integrity": "sha512-h/Fi+o7mti4n8wx1SR6UHWLaakwHRx29sizvp8OOm7iqwKGFneT06GCSFhml6Bha5BT6ot5pj3CYZnCHhGC2Rg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/querystring-builder": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-base64": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.7.tgz",
+      "integrity": "sha512-PU/JWLTBCV1c8FtB8tEFnY4eV1tSfBc7bDBADHfn1K+uRbPgSJ9jnJp0hyjiFN2PMdPzxsf1Fdu0eo9fJ760Xw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.7.tgz",
+      "integrity": "sha512-ncvgCr9a15nPlkhIUx3CU4d7E7WEuVJOV7fS7nnK2hLtPK9tYRBkMHQbhXU1VvvKeBm/O0x26OEoBq+ngFpOEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-compression": {
+      "version": "4.3.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-compression/-/middleware-compression-4.3.16.tgz",
+      "integrity": "sha512-df41cMk8D/Aa8JRhraZPbeHYUJ012ivOTp9kOs95amfMdRvgNFWz9/qBFbpnTEbsyvFtYfF4HjZ0bgzrkguECQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.20.0",
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
+        "fflate": "0.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.7.tgz",
+      "integrity": "sha512-GszfBfCcvt7kIbJ41LuNa5f0wvQCHhnGx/aDaZJCCT05Ld6x6U2s0xsc/0mBFONBZjQJp2U/0uSJ178OXOwbhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.1.tgz",
+      "integrity": "sha512-gpLspUAoe6f1M6H0u4cVuFzxZBrsGZmjx2O9SigurTx4PbntYa4AJ+o0G0oGm1L2oSX6oBhcGHwrfJHup2JnJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.20.0",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.17.tgz",
+      "integrity": "sha512-MqbXK6Y9uq17h+4r0ogu/sBT6V/rdV+5NvYL7ZV444BKfQygYe8wAhDrVXagVebN6w2RE0Fm245l69mOsPGZzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/service-error-classification": "^4.2.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.8.tgz",
+      "integrity": "sha512-8rDGYen5m5+NV9eHv9ry0sqm2gI6W7mc1VSFMtn6Igo25S507/HaOX9LTHAS2/J32VXD0xSzrY0H5FJtOMS4/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.7.tgz",
+      "integrity": "sha512-bsOT0rJ+HHlZd9crHoS37mt8qRRN/h9jRve1SXUhVbkRzu0QaNYZp1i1jha4n098tsvROjcwfLlfvcFuJSXEsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.7.tgz",
+      "integrity": "sha512-7r58wq8sdOcrwWe+klL9y3bc4GW1gnlfnFOuL7CXa7UzfhzhxKuzNdtqgzmTV+53lEp9NXh5hY/S4UgjLOzPfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.7.tgz",
+      "integrity": "sha512-NELpdmBOO6EpZtWgQiHjoShs1kmweaiNuETUpuup+cmm/xJYjT4eUjfhrXRP4jCOaAsS3c3yPsP3B+K+/fyPCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/querystring-builder": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.7.tgz",
+      "integrity": "sha512-jmNYKe9MGGPoSl/D7JDDs1C8b3dC8f/w78LbaVfoTtWy4xAd5dfjaFG9c9PWPihY4ggMQNQSMtzU77CNgAJwmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
+      "integrity": "sha512-1r07pb994I20dD/c2seaZhoCuNYm0rWrvBxhCQ70brNh11M5Ml2ew6qJVo0lclB3jMIXirD4s2XRXRe7QEi0xA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.7.tgz",
+      "integrity": "sha512-eKONSywHZxK4tBxe2lXEysh8wbBdvDWiA+RIuaxZSgCMmA0zMgoDpGLJhnyj+c0leOQprVnXOmcB4m+W9Rw7sg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.7.tgz",
+      "integrity": "sha512-3X5ZvzUHmlSTHAXFlswrS6EGt8fMSIxX/c3Rm1Pni3+wYWB6cjGocmRIoqcQF9nU5OgGmL0u7l9m44tSUpfj9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.7.tgz",
+      "integrity": "sha512-YB7oCbukqEb2Dlh3340/8g8vNGbs/QsNNRms+gv3N2AtZz9/1vSBx6/6tpwQpZMEJFs7Uq8h4mmOn48ZZ72MkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.2.tgz",
+      "integrity": "sha512-M7iUUff/KwfNunmrgtqBfvZSzh3bmFgv/j/t1Y1dQ+8dNo34br1cqVEqy6v0mYEgi0DkGO7Xig0AnuOaEGVlcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.7.tgz",
+      "integrity": "sha512-9oNUlqBlFZFOSdxgImA6X5GFuzE7V2H7VG/7E70cdLhidFbdtvxxt81EHgykGK5vq5D3FafH//X+Oy31j3CKOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.2.tgz",
+      "integrity": "sha512-D5z79xQWpgrGpAHb054Fn2CCTQZpog7JELbVQ6XAvXs5MNKWf28U9gzSBlJkOyMl9LA1TZEjRtwvGXfP0Sl90g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.20.0",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-stream": "^4.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.11.0.tgz",
+      "integrity": "sha512-mlrmL0DRDVe3mNrjTcVcZEgkFmufITfUAPBEA+AHYiIeYyJebso/He1qLbP3PssRe22KUzLRpQSdBPbXdgZ2VA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.7.tgz",
+      "integrity": "sha512-/RLtVsRV4uY3qPWhBDsjwahAtt3x2IsMGnP5W1b2VZIe+qgCqkLxI1UOHDZp1Q1QSOrdOR32MF3Ph2JfWT1VHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.16",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.16.tgz",
+      "integrity": "sha512-/eiSP3mzY3TsvUOYMeL4EqUX6fgUOj2eUOU4rMMgVbq67TiRLyxT7Xsjxq0bW3OwuzK009qOwF0L2OgJqperAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.19",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.19.tgz",
+      "integrity": "sha512-3a4+4mhf6VycEJyHIQLypRbiwG6aJvbQAeRAVXydMmfweEPnLLabRbdyo/Pjw8Rew9vjsh5WCdhmDaHkQnhhhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/credential-provider-imds": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.7.tgz",
+      "integrity": "sha512-s4ILhyAvVqhMDYREeTS68R43B1V5aenV5q/V1QpRQJkCXib5BPRo4s7uNdzGtIKxaPHCfU/8YkvPAEvTpxgspg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.7.tgz",
+      "integrity": "sha512-i1IkpbOae6NvIKsEeLLM9/2q4X+M90KV3oCFgWQI4q0Qz+yUZvsr+gZPdAEAtFhWQhAHpTsJO8DRJPuwVyln+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.7.tgz",
+      "integrity": "sha512-SvDdsQyF5CIASa4EYVT02LukPHVzAgUA4kMAuZ97QJc2BpAqZfA4PINB8/KOoCXEw9tsuv/jQjMeaHFvxdLNGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.8.tgz",
+      "integrity": "sha512-ZnnBhTapjM0YPGUSmOs0Mcg/Gg87k503qG4zU2v/+Js2Gu+daKOJMeqcQns8ajepY8tgzzfYxl6kQyZKml6O2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.7.tgz",
+      "integrity": "sha512-vHJFXi9b7kUEpHWUCY3Twl+9NPOZvQ0SAi+Ewtn48mbiJk4JY9MZmKQjGB4SCvVb9WPiSphZJYY6RIbs+grrzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
+      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@wry/caches": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/context": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.13.1.tgz",
+      "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
+      "license": "MIT"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.1.tgz",
+      "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==",
+      "license": "MIT"
+    },
+    "node_modules/graphql": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/graphql-ws": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.6.tgz",
+      "integrity": "sha512-zgfER9s+ftkGKUZgc0xbx8T7/HMO4AV5/YuYiFc+AtgcO5T0v8AxYYNQ+ltzuzDZgNkYJaFspm5MMYLjQzrkmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@fastify/websocket": "^10 || ^11",
+        "crossws": "~0.3",
+        "graphql": "^15.10.1 || ^16",
+        "uWebSockets.js": "^20",
+        "ws": "^8"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/websocket": {
+          "optional": true
+        },
+        "crossws": {
+          "optional": true
+        },
+        "uWebSockets.js": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/optimism": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
+      "integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wry/caches": "^1.0.0",
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.5.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/test/load-test/package.json
+++ b/test/load-test/package.json
@@ -14,9 +14,10 @@
   },
   "scripts": {
     "setup": "npm install",
-    "run:data-update": "node scenario-data-update.js",
-    "run:event-notification": "node scenario-event-notification.js",
-    "run:multi-group": "node scenario-multi-group.js",
-    "report": "node generate-report.js"
+    "test:data-update": "node mesh-v2-data-update-load.js",
+    "test:event": "node mesh-v2-event-load.js",
+    "test:multi-group": "node mesh-v2-multi-group-load.js",
+    "test:all": "npm run test:data-update && npm run test:event && npm run test:multi-group",
+    "report": "node mesh-v2-load-report.js"
   }
 }

--- a/test/load-test/package.json
+++ b/test/load-test/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "scratch-vm-load-test",
+  "version": "1.0.0",
+  "description": "Load testing scripts for MESH v2",
+  "private": true,
+  "dependencies": {
+    "@apollo/client": "^4.0.11",
+    "@aws-sdk/client-cloudwatch": "^3.958.0",
+    "chart.js": "^4.5.1",
+    "cross-fetch": "^4.1.0",
+    "graphql": "^16.12.0",
+    "graphql-ws": "^6.0.6",
+    "ws": "^8.18.3"
+  },
+  "scripts": {
+    "setup": "npm install",
+    "run:data-update": "node scenario-data-update.js",
+    "run:event-notification": "node scenario-event-notification.js",
+    "run:multi-group": "node scenario-multi-group.js",
+    "report": "node generate-report.js"
+  }
+}


### PR DESCRIPTION
Implementation of MESH v2 load testing scripts as described in issue #68.

Includes:
- MeshClientSimulator for simulating MESH v2 nodes
- LoadTestMetrics for performance data collection
- Scenarios for data update, event notification, and multi-group tests
- Report generation script

Verified with syntax check and linting.
Co-Authored-By: Gemini <noreply@google.com>