### PR TITLE
feat: add DynamoDB metrics monitoring script for load tests

### DIFF
--- a/test/load-test/check-dynamodb-metrics.sh
+++ b/test/load-test/check-dynamodb-metrics.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# DynamoDB メトリクス確認スクリプト
+# MESH v2 負荷テスト用 - DynamoDBのスロットリングとパフォーマンスを確認
+
+set -e
+
+TABLE_NAME="${1:-}"
+HOURS_AGO="${2:-1}"
+
+if [ -z "$TABLE_NAME" ]; then
+  echo "使用方法: $0 <テーブル名> [時間前(デフォルト:1)]"
+  echo ""
+  echo "例:"
+  echo "  $0 mesh-v2-groups-table       # 過去1時間のメトリクスを表示"
+  echo "  $0 mesh-v2-groups-table 2     # 過去2時間のメトリクスを表示"
+  echo ""
+  echo "利用可能なテーブル一覧:"
+  aws dynamodb list-tables --query 'TableNames' --output table 2>/dev/null || echo "  (AWS CLIでテーブル一覧を取得できませんでした)"
+  exit 1
+fi
+
+# macOS/Linux 互換の日付計算
+if date --version >/dev/null 2>&1; then
+  # GNU date (Linux)
+  START_TIME=$(date -u -d "$HOURS_AGO hours ago" +"%Y-%m-%dT%H:%M:%SZ")
+  END_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+else
+  # BSD date (macOS)
+  START_TIME=$(date -u -v-${HOURS_AGO}H +"%Y-%m-%dT%H:%M:%SZ")
+  END_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+fi
+
+echo "========================================="
+echo "DynamoDB メトリクス確認"
+echo "========================================="
+echo "テーブル名: $TABLE_NAME"
+echo "期間: $START_TIME ～ $END_TIME"
+echo "========================================="
+echo ""
+
+# テーブルの課金モードを確認
+echo "【課金モード】"
+aws dynamodb describe-table \
+  --table-name "$TABLE_NAME" \
+  --query 'Table.BillingModeSummary' \
+  --output table 2>/dev/null || echo "  テーブル情報を取得できませんでした"
+echo ""
+
+# 1. スロットリング確認（最重要）
+echo "【1. スロットリング発生数】★最重要★"
+echo "   期待値: 0 (スロットリングが発生していないこと)"
+THROTTLED=$(aws cloudwatch get-metric-statistics \
+  --namespace AWS/DynamoDB \
+  --metric-name ThrottledRequests \
+  --dimensions Name=TableName,Value="$TABLE_NAME" \
+  --start-time "$START_TIME" \
+  --end-time "$END_TIME" \
+  --period 300 \
+  --statistics Sum \
+  --query 'Datapoints[*].[Timestamp,Sum]' \
+  --output table 2>/dev/null)
+
+if [ -z "$THROTTLED" ] || echo "$THROTTLED" | grep -q "None"; then
+  echo "   ✅ データなし（スロットリングなし）"
+else
+  echo "$THROTTLED"
+  # スロットリングがあるか確認
+  if echo "$THROTTLED" | grep -q "|.*[1-9]"; then
+    echo "   ⚠️  警告: スロットリングが発生しています！"
+  else
+    echo "   ✅ スロットリングなし"
+  fi
+fi
+echo ""
+
+# 2. 読み込みキャパシティ
+echo "【2. 読み込みキャパシティ消費量】"
+aws cloudwatch get-metric-statistics \
+  --namespace AWS/DynamoDB \
+  --metric-name ConsumedReadCapacityUnits \
+  --dimensions Name=TableName,Value="$TABLE_NAME" \
+  --start-time "$START_TIME" \
+  --end-time "$END_TIME" \
+  --period 300 \
+  --statistics Average,Maximum \
+  --query 'Datapoints[*].[Timestamp,Average,Maximum]' \
+  --output table 2>/dev/null || echo "   データなし"
+echo ""
+
+# 3. 書き込みキャパシティ
+echo "【3. 書き込みキャパシティ消費量】"
+aws cloudwatch get-metric-statistics \
+  --namespace AWS/DynamoDB \
+  --metric-name ConsumedWriteCapacityUnits \
+  --dimensions Name=TableName,Value="$TABLE_NAME" \
+  --start-time "$START_TIME" \
+  --end-time "$END_TIME" \
+  --period 300 \
+  --statistics Average,Maximum \
+  --query 'Datapoints[*].[Timestamp,Average,Maximum]' \
+  --output table 2>/dev/null || echo "   データなし"
+echo ""
+
+# 4. システムエラー
+echo "【4. システムエラー】"
+echo "   期待値: 0"
+SYSTEM_ERRORS=$(aws cloudwatch get-metric-statistics \
+  --namespace AWS/DynamoDB \
+  --metric-name SystemErrors \
+  --dimensions Name=TableName,Value="$TABLE_NAME" \
+  --start-time "$START_TIME" \
+  --end-time "$END_TIME" \
+  --period 300 \
+  --statistics Sum \
+  --query 'Datapoints[*].[Timestamp,Sum]' \
+  --output table 2>/dev/null)
+
+if [ -z "$SYSTEM_ERRORS" ] || echo "$SYSTEM_ERRORS" | grep -q "None"; then
+  echo "   ✅ データなし（エラーなし）"
+else
+  echo "$SYSTEM_ERRORS"
+fi
+echo ""
+
+# 5. ユーザーエラー
+echo "【5. ユーザーエラー】"
+echo "   期待値: 0 または 非常に少ない"
+USER_ERRORS=$(aws cloudwatch get-metric-statistics \
+  --namespace AWS/DynamoDB \
+  --metric-name UserErrors \
+  --dimensions Name=TableName,Value="$TABLE_NAME" \
+  --start-time "$START_TIME" \
+  --end-time "$END_TIME" \
+  --period 300 \
+  --statistics Sum \
+  --query 'Datapoints[*].[Timestamp,Sum]' \
+  --output table 2>/dev/null)
+
+if [ -z "$USER_ERRORS" ] || echo "$USER_ERRORS" | grep -q "None"; then
+  echo "   ✅ データなし（エラーなし）"
+else
+  echo "$USER_ERRORS"
+fi
+echo ""
+
+echo "========================================="
+echo "確認完了"
+echo "========================================="


### PR DESCRIPTION
## 概要

MESH v2負荷テストのDynamoDBパフォーマンス監視機能を追加しました。負荷テスト実行時のスロットリング検出とキャパシティ消費量の確認が簡単にできるようになります。

## 追加機能

### 1. `check-dynamodb-metrics.sh` スクリプト

DynamoDBのメトリクスを自動的にチェックするシェルスクリプトです。

**主な機能**:
- ✅ スロットリング発生数の確認（ThrottledRequests）- 最重要
- ✅ 読み込みキャパシティ消費量の監視（ConsumedReadCapacityUnits）
- ✅ 書き込みキャパシティ消費量の監視（ConsumedWriteCapacityUnits）
- ✅ システムエラーの検出（SystemErrors）
- ✅ ユーザーエラーの検出（UserErrors）
- ✅ 課金モードの表示（PAY_PER_REQUEST / PROVISIONED）
- ✅ カスタム時間範囲のサポート（デフォルト: 過去1時間）
- ✅ macOS/Linux両対応の日付処理

### 2. README.md更新

新しいセクション「DynamoDB Performance Monitoring」を追加:
- スクリプトの使い方（日本語で説明）
- 確認項目の詳細説明
- テーブル名の確認方法
- スロットリング発生時のトラブルシューティングガイド

## 使用例

```bash
cd test/load-test

# 基本的な使い方（過去1時間のメトリクスを確認）
./check-dynamodb-metrics.sh mesh-v2-groups-table

# 過去2時間のメトリクスを確認
./check-dynamodb-metrics.sh mesh-v2-groups-table 2

# 使い方とテーブル一覧を表示
./check-dynamodb-metrics.sh
```

## 出力例

```
=========================================
DynamoDB メトリクス確認
=========================================
テーブル名: mesh-v2-groups-table
期間: 2025-12-31T13:00:00Z ～ 2025-12-31T14:00:00Z
=========================================

【課金モード】
BillingMode: PAY_PER_REQUEST

【1. スロットリング発生数】★最重要★
   期待値: 0 (スロットリングが発生していないこと)
   ✅ データなし（スロットリングなし）

【2. 読み込みキャパシティ消費量】
| Timestamp           | Average | Maximum |
|---------------------|---------|---------|
| 2025-12-31 13:15:00 | 12.5    | 25.0    |
| 2025-12-31 13:20:00 | 15.2    | 30.1    |
...
```

## 技術詳細

### CloudWatch メトリクス

以下のDynamoDB CloudWatchメトリクスを取得します：

- `ThrottledRequests`: スロットリング発生回数（0であることが理想）
- `ConsumedReadCapacityUnits`: 読み込みに使用されたキャパシティユニット
- `ConsumedWriteCapacityUnits`: 書き込みに使用されたキャパシティユニット
- `SystemErrors`: DynamoDB側のシステムエラー
- `UserErrors`: アプリケーション側のエラー

### 日付処理の互換性

macOSとLinuxの両方で動作するよう、`date`コマンドの違いに対応：

```bash
# GNU date (Linux)
date -d "1 hour ago"

# BSD date (macOS)
date -v-1H
```

## テスト

### 動作確認

```bash
# スクリプトの実行権限確認
ls -l check-dynamodb-metrics.sh
# -rwxr-xr-x ... check-dynamodb-metrics.sh

# ヘルプ表示確認
./check-dynamodb-metrics.sh
# → 使い方とテーブル一覧が表示される

# 実際のテーブルで実行（環境によって異なる）
./check-dynamodb-metrics.sh mesh-v2-groups-table
# → メトリクスが正常に表示される
```

## 関連Issue

- GitHub Issue #68 - MESH v2 load testing implementation

## チェックリスト

- [x] スクリプトに実行権限を付与
- [x] macOS/Linux両対応を確認
- [x] README.mdに日本語の使用方法を追加
- [x] エラーハンドリングの実装
- [x] 分かりやすい出力フォーマット

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>