### PR TITLE
feat: use last modified value for meshV2 sensor value block

### DIFF
--- a/test/integration/extensions/mesh-v2-variable-sync.test.js
+++ b/test/integration/extensions/mesh-v2-variable-sync.test.js
@@ -165,7 +165,7 @@ test('MeshV2Service fetch existing nodes data on joinGroup', async t => {
     await service.joinGroup('group1', 'domain1', 'groupName');
 
     t.ok(service.remoteData['host-node'], 'Should have data from host-node');
-    t.equal(service.remoteData['host-node'].hostVar, '100', 'Should have correct variable value from host');
+    t.equal(service.remoteData['host-node'].hostVar.value, '100', 'Should have correct variable value from host');
 
     service.cleanup();
     t.end();

--- a/test/unit/mesh_service_v2_timestamp.js
+++ b/test/unit/mesh_service_v2_timestamp.js
@@ -1,0 +1,84 @@
+const test = require('tap').test;
+const MeshV2Service = require('../../src/extensions/scratch3_mesh_v2/mesh-service');
+
+const createMockBlocks = () => ({
+    runtime: {
+        sequencer: {},
+        emit: () => {},
+        on: () => {},
+        off: () => {}
+    }
+});
+
+test('MeshV2Service Timestamp-based getRemoteVariable', t => {
+    const blocks = createMockBlocks();
+    const service = new MeshV2Service(blocks, 'node-self', 'domain1');
+    service.groupId = 'group1';
+
+    t.test('should return the latest value based on timestamp', st => {
+        // Setup remoteData with multiple nodes having the same key
+        const now = Date.now();
+        service.remoteData = {
+            node1: {
+                'my var': {value: 'value-old', timestamp: now - 1000}
+            },
+            node2: {
+                'my var': {value: 'value-newest', timestamp: now}
+            },
+            node3: {
+                'my var': {value: 'value-middle', timestamp: now - 500}
+            }
+        };
+
+        const result = service.getRemoteVariable('my var');
+        st.equal(result, 'value-newest', 'Should return the value with the largest timestamp');
+        st.end();
+    });
+
+    t.test('handleDataUpdate should add timestamp', st => {
+        const nodeStatus = {
+            nodeId: 'node4',
+            data: [
+                {key: 'var1', value: '100'}
+            ]
+        };
+
+        const beforeUpdate = Date.now();
+        service.handleDataUpdate(nodeStatus);
+        const afterUpdate = Date.now();
+
+        st.ok(service.remoteData.node4, 'Node 4 should be added');
+        st.ok(service.remoteData.node4.var1, 'var1 should be added');
+        st.equal(service.remoteData.node4.var1.value, '100');
+        st.ok(service.remoteData.node4.var1.timestamp >= beforeUpdate);
+        st.ok(service.remoteData.node4.var1.timestamp <= afterUpdate);
+        st.end();
+    });
+
+    t.test('fetchAllNodesData should add timestamp', async st => {
+        service.client = {
+            query: () => Promise.resolve({
+                data: {
+                    listGroupStatuses: [
+                        {
+                            nodeId: 'node5',
+                            data: [{key: 'var2', value: '200'}]
+                        }
+                    ]
+                }
+            })
+        };
+
+        const beforeFetch = Date.now();
+        await service.fetchAllNodesData();
+        const afterFetch = Date.now();
+
+        st.ok(service.remoteData.node5, 'Node 5 should be added');
+        st.equal(service.remoteData.node5.var2.value, '200');
+        st.ok(service.remoteData.node5.var2.timestamp >= beforeFetch);
+        st.ok(service.remoteData.node5.var2.timestamp <= afterFetch);
+        st.end();
+    });
+
+    t.end();
+});


### PR DESCRIPTION
## Summary
When multiple nodes have data with the same name (e.g., "my variable"), the meshV2 sensor value block should return the most recently modified value.

## Proposed Changes
- Updated `remoteData` structure to include timestamps for each data key: `{ nodeId: { key: { value: string, timestamp: number } } }`
- Modified `handleDataUpdate` and `fetchAllNodesData` to store `Date.now()` when receiving or fetching data
- Updated `getRemoteVariable` to iterate through all nodes and return the value with the largest timestamp
- Added unit tests in `test/unit/mesh_service_v2_timestamp.js` to verify the timestamp-based selection logic
- Updated existing integration test `test/integration/extensions/mesh-v2-variable-sync.test.js` to match the new `remoteData` structure

## Test Coverage
- New unit test: `test/unit/mesh_service_v2_timestamp.js`
- Updated integration test: `test/integration/extensions/mesh-v2-variable-sync.test.js`
- All tests passed with `npm test`

Resolves: smalruby/smalruby3-gui#492