### PR TITLE
feat: use legacy message IDs and formats for Mesh V2 connected status

### DIFF
--- a/src/extensions/scratch3_mesh/mesh-service.js
+++ b/src/extensions/scratch3_mesh/mesh-service.js
@@ -74,8 +74,8 @@ class MeshService {
                     this.availablePeripherals[hostMeshId] = {
                         name: formatMessage({
                             id: 'mesh.hostPeripheralName',
-                            default: 'Host Mesh [{ MESH_ID }]',
-                            description: 'label for "Host Mesh" in connect modal for Mesh extension'
+                            default: 'Become Mesh Host [{ MESH_ID }]',
+                            description: 'label for becoming Host Mesh in connect modal for Mesh extension'
                         }, {MESH_ID: this.blocks.makeMeshIdLabel(this.meshId)}),
                         peripheralId: hostMeshId,
                         rssi: 0

--- a/src/extensions/scratch3_mesh_v2/index.js
+++ b/src/extensions/scratch3_mesh_v2/index.js
@@ -181,9 +181,9 @@ class Scratch3MeshV2Blocks {
             const peripherals = validGroups.map(group => ({
                 peripheralId: group.id,
                 name: formatMessage({
-                    id: 'mesh.clientPeripheralNameV2',
-                    default: 'Join Mesh V2 [{ MESH_ID }]',
-                    description: 'label for joining Mesh in connect modal for Mesh V2 extension'
+                    id: 'mesh.clientPeripheralName',
+                    default: 'Join Mesh [{ MESH_ID }]',
+                    description: 'label for "Join Mesh" in connect modal for Mesh extension'
                 }, {MESH_ID: this.makeMeshIdLabel(group.name)}),
                 rssi: this.calculateRssi(group),
                 domain: group.domain
@@ -193,9 +193,9 @@ class Scratch3MeshV2Blocks {
             peripherals.unshift({
                 peripheralId: MESH_V2_HOST_ID,
                 name: formatMessage({
-                    id: 'mesh.hostPeripheralNameV2',
-                    default: 'Become Mesh V2 Host [{ MESH_ID }]',
-                    description: 'label for becoming Host Mesh in connect modal for Mesh V2 extension'
+                    id: 'mesh.hostPeripheralName',
+                    default: 'Become Mesh Host [{ MESH_ID }]',
+                    description: 'label for becoming Host Mesh in connect modal for Mesh extension'
                 }, {MESH_ID: this.makeMeshIdLabel(this.nodeId)}),
                 rssi: 0
             });
@@ -320,9 +320,9 @@ class Scratch3MeshV2Blocks {
             }, {MESH_ID: meshIdLabel});
         }
         return formatMessage({
-            id: 'mesh.notConnectedV2',
-            default: 'Not connected (Mesh V2)',
-            description: 'label for not connected in connect modal for Mesh V2 extension'
+            id: 'mesh.notConnected',
+            default: 'Not connected',
+            description: 'label for not connected in connect modal for Mesh extension'
         });
     }
 

--- a/src/extensions/scratch3_mesh_v2/index.js
+++ b/src/extensions/scratch3_mesh_v2/index.js
@@ -303,32 +303,20 @@ class Scratch3MeshV2Blocks {
     connectedMessage () {
         if (this.meshService && this.meshService.groupId) {
             const meshIdLabel = this.makeMeshIdLabel(this.meshService.groupName);
-            const expiresAt = this.meshService.expiresAt ?
-                new Date(this.meshService.expiresAt).toLocaleTimeString([], {
-                    hour: '2-digit',
-                    minute: '2-digit'
-                }) : null;
 
             if (this.meshService.isHost) {
-                const expiresAtMessage = expiresAt ? formatMessage({
-                    id: 'mesh.expiresAtV2',
-                    default: ' (Expires at { TIME })',
-                    description: 'label for expiration time in connect modal for Mesh V2 extension'
-                }, {TIME: expiresAt}) : '';
-
                 return formatMessage({
-                    id: 'mesh.registeredHostV2',
-                    default: 'Registered Host Mesh V2 [{ MESH_ID }]{ EXPIRES_AT }',
-                    description: 'label for registered Host Mesh in connect modal for Mesh V2 extension'
+                    id: 'mesh.registeredHost',
+                    default: 'Registered Host Mesh [{ MESH_ID }]',
+                    description: 'label for registered Host Mesh in connect modal for Mesh extension'
                 }, {
-                    MESH_ID: meshIdLabel,
-                    EXPIRES_AT: expiresAtMessage
+                    MESH_ID: meshIdLabel
                 });
             }
             return formatMessage({
-                id: 'mesh.joinedMeshV2',
-                default: 'Joined Mesh V2 [{ MESH_ID }]',
-                description: 'label for joined Mesh in connect modal for Mesh V2 extension'
+                id: 'mesh.joinedMesh',
+                default: 'Joined Mesh [{ MESH_ID }]',
+                description: 'label for joined Mesh in connect modal for Mesh extension'
             }, {MESH_ID: meshIdLabel});
         }
         return formatMessage({


### PR DESCRIPTION
Updates Mesh V2 connected messages to match legacy mesh extension for backward compatibility.

- Updates connectedMessage to use legacy message IDs: mesh.registeredHost and mesh.joinedMesh
- Removes the expiration time display from the messages
- Part of smalruby/smalruby3-gui#493