### PR TITLE
feat: display expiry time in meshV2 connected message

### DIFF
--- a/src/extensions/scratch3_mesh_v2/gql-operations.js
+++ b/src/extensions/scratch3_mesh_v2/gql-operations.js
@@ -42,6 +42,7 @@ const JOIN_GROUP = gql`
       name
       groupId
       domain
+      expiresAt
       heartbeatIntervalSeconds
     }
   }

--- a/src/extensions/scratch3_mesh_v2/index.js
+++ b/src/extensions/scratch3_mesh_v2/index.js
@@ -311,31 +311,58 @@ class Scratch3MeshV2Blocks {
     connectedMessage () {
         if (this.meshService && this.meshService.groupId) {
             const meshIdLabel = this.makeMeshIdLabel(this.meshService.groupName);
-            const expiresAt = this.formatExpiresAt(this.meshService.expiresAt);
 
             if (this.meshService.isHost) {
                 return formatMessage({
                     id: 'mesh.registeredHost',
-                    default: 'Registered Host Mesh [{ MESH_ID }] ({ EXPIRES_AT })',
+                    default: 'Registered Host Mesh [{ MESH_ID }]',
                     description: 'label for registered Host Mesh in connect modal for Mesh extension'
+                }, {
+                    MESH_ID: meshIdLabel
+                });
+            }
+            return formatMessage({
+                id: 'mesh.joinedMesh',
+                default: 'Joined Mesh [{ MESH_ID }]',
+                description: 'label for joined Mesh in connect modal for Mesh extension'
+            }, {MESH_ID: meshIdLabel});
+        }
+        return formatMessage({
+            id: 'mesh.notConnected',
+            default: 'Not connected',
+            description: 'label for not connected in connect modal for Mesh extension'
+        });
+    }
+
+    /* istanbul ignore next */
+    menuMessage () {
+        if (this.meshService && this.meshService.groupId) {
+            const meshIdLabel = this.makeMeshIdLabel(this.meshService.groupName);
+            const expiresAt = this.formatExpiresAt(this.meshService.expiresAt);
+
+            if (this.meshService.isHost) {
+                return formatMessage({
+                    id: 'mesh.registeredHostMenu',
+                    default: '{ MESH_ID } ({ EXPIRES_AT })',
+                    description: 'concise label for registered Host Mesh in menu bar'
                 }, {
                     MESH_ID: meshIdLabel,
                     EXPIRES_AT: expiresAt
                 });
             }
             return formatMessage({
-                id: 'mesh.joinedMesh',
-                default: 'Joined Mesh [{ MESH_ID }] ({ EXPIRES_AT })',
-                description: 'label for joined Mesh in connect modal for Mesh extension'
+                id: 'mesh.joinedMeshMenu',
+                default: '{ MESH_ID } ({ EXPIRES_AT })',
+                description: 'concise label for joined Mesh in menu bar'
             }, {
                 MESH_ID: meshIdLabel,
                 EXPIRES_AT: expiresAt
             });
         }
         return formatMessage({
-            id: 'mesh.notConnected',
+            id: 'mesh.notConnectedMenu',
             default: 'Not connected',
-            description: 'label for not connected in connect modal for Mesh extension'
+            description: 'concise label for not connected in menu bar'
         });
     }
 

--- a/src/extensions/scratch3_mesh_v2/index.js
+++ b/src/extensions/scratch3_mesh_v2/index.js
@@ -299,25 +299,38 @@ class Scratch3MeshV2Blocks {
         return !!(this.meshService && this.meshService.groupId);
     }
 
+    formatExpiresAt (expiresAt) {
+        if (!expiresAt) return '';
+        const date = new Date(expiresAt);
+        const h = String(date.getHours()).padStart(2, '0');
+        const m = String(date.getMinutes()).padStart(2, '0');
+        return `${h}:${m}`;
+    }
+
     /* istanbul ignore next */
     connectedMessage () {
         if (this.meshService && this.meshService.groupId) {
             const meshIdLabel = this.makeMeshIdLabel(this.meshService.groupName);
+            const expiresAt = this.formatExpiresAt(this.meshService.expiresAt);
 
             if (this.meshService.isHost) {
                 return formatMessage({
                     id: 'mesh.registeredHost',
-                    default: 'Registered Host Mesh [{ MESH_ID }]',
+                    default: 'Registered Host Mesh [{ MESH_ID }] ({ EXPIRES_AT })',
                     description: 'label for registered Host Mesh in connect modal for Mesh extension'
                 }, {
-                    MESH_ID: meshIdLabel
+                    MESH_ID: meshIdLabel,
+                    EXPIRES_AT: expiresAt
                 });
             }
             return formatMessage({
                 id: 'mesh.joinedMesh',
-                default: 'Joined Mesh [{ MESH_ID }]',
+                default: 'Joined Mesh [{ MESH_ID }] ({ EXPIRES_AT })',
                 description: 'label for joined Mesh in connect modal for Mesh extension'
-            }, {MESH_ID: meshIdLabel});
+            }, {
+                MESH_ID: meshIdLabel,
+                EXPIRES_AT: expiresAt
+            });
         }
         return formatMessage({
             id: 'mesh.notConnected',

--- a/src/extensions/scratch3_mesh_v2/index.js
+++ b/src/extensions/scratch3_mesh_v2/index.js
@@ -77,7 +77,6 @@ class Scratch3MeshV2Blocks {
         }
 
         this.runtime.registerPeripheralExtension(Scratch3MeshV2Blocks.EXTENSION_ID, this);
-        console.log('Scratch3MeshV2Blocks: constructor finished, registered as:', Scratch3MeshV2Blocks.EXTENSION_ID);
     }
 
     makeMeshIdLabel (meshId) {

--- a/src/extensions/scratch3_mesh_v2/index.js
+++ b/src/extensions/scratch3_mesh_v2/index.js
@@ -77,6 +77,7 @@ class Scratch3MeshV2Blocks {
         }
 
         this.runtime.registerPeripheralExtension(Scratch3MeshV2Blocks.EXTENSION_ID, this);
+        console.log('Scratch3MeshV2Blocks: constructor finished, registered as:', Scratch3MeshV2Blocks.EXTENSION_ID);
     }
 
     makeMeshIdLabel (meshId) {


### PR DESCRIPTION
This PR adds the expiry time to the meshV2 connected message.
It is part of the implementation for smalruby/smalruby3-gui#494.

- Added formatExpiresAt method to Scratch3MeshV2Blocks
- Updated connectedMessage to include EXPIRES_AT placeholder