### PR TITLE
feat: optimize Mesh V2 event queue to prevent bloating

### DIFF
--- a/src/extensions/scratch3_mesh_v2/gql-operations.js
+++ b/src/extensions/scratch3_mesh_v2/gql-operations.js
@@ -64,7 +64,11 @@ const DISSOLVE_GROUP = gql`
     dissolveGroup(groupId: $groupId, domain: $domain, hostId: $hostId) {
       groupId
       domain
-      message
+      groupDissolve {
+        groupId
+        domain
+        message
+      }
     }
   }
 `;
@@ -95,14 +99,18 @@ const SEND_MEMBER_HEARTBEAT = gql`
 const REPORT_DATA = gql`
   mutation ReportDataByNode($groupId: ID!, $domain: String!, $nodeId: ID!, $data: [SensorDataInput!]!) {
     reportDataByNode(groupId: $groupId, domain: $domain, nodeId: $nodeId, data: $data) {
-      nodeId
       groupId
       domain
-      data {
-        key
-        value
+      nodeStatus {
+        nodeId
+        groupId
+        domain
+        data {
+          key
+          value
+        }
+        timestamp
       }
-      timestamp
     }
   }
 `;
@@ -110,62 +118,60 @@ const REPORT_DATA = gql`
 const FIRE_EVENTS = gql`
   mutation FireEventsByNode($groupId: ID!, $domain: String!, $nodeId: ID!, $events: [EventInput!]!) {
     fireEventsByNode(groupId: $groupId, domain: $domain, nodeId: $nodeId, events: $events) {
-      events {
-        name
+      groupId
+      domain
+      batchEvent {
+        events {
+          name
+          firedByNodeId
+          groupId
+          domain
+          payload
+          timestamp
+        }
         firedByNodeId
         groupId
         domain
-        payload
         timestamp
       }
-      firedByNodeId
-      groupId
-      domain
-      timestamp
     }
   }
 `;
 
-const ON_DATA_UPDATE = gql`
-  subscription OnDataUpdateInGroup($groupId: ID!, $domain: String!) {
-    onDataUpdateInGroup(groupId: $groupId, domain: $domain) {
-      nodeId
+const ON_MESSAGE_IN_GROUP = gql`
+  subscription OnMessageInGroup($groupId: ID!, $domain: String!) {
+    onMessageInGroup(groupId: $groupId, domain: $domain) {
       groupId
       domain
-      data {
-        key
-        value
+      nodeStatus {
+        nodeId
+        groupId
+        domain
+        data {
+          key
+          value
+        }
+        timestamp
       }
-      timestamp
-    }
-  }
-`;
-
-const ON_BATCH_EVENT = gql`
-  subscription OnBatchEventInGroup($groupId: ID!, $domain: String!) {
-    onBatchEventInGroup(groupId: $groupId, domain: $domain) {
-      events {
-        name
+      batchEvent {
+        events {
+          name
+          firedByNodeId
+          groupId
+          domain
+          payload
+          timestamp
+        }
         firedByNodeId
         groupId
         domain
-        payload
         timestamp
       }
-      firedByNodeId
-      groupId
-      domain
-      timestamp
-    }
-  }
-`;
-
-const ON_GROUP_DISSOLVE = gql`
-  subscription OnGroupDissolve($groupId: ID!, $domain: String!) {
-    onGroupDissolve(groupId: $groupId, domain: $domain) {
-      groupId
-      domain
-      message
+      groupDissolve {
+        groupId
+        domain
+        message
+      }
     }
   }
 `;
@@ -196,8 +202,6 @@ module.exports = {
     SEND_MEMBER_HEARTBEAT,
     REPORT_DATA,
     FIRE_EVENTS,
-    ON_DATA_UPDATE,
-    ON_BATCH_EVENT,
-    ON_GROUP_DISSOLVE,
+    ON_MESSAGE_IN_GROUP,
     LIST_GROUP_STATUSES
 };

--- a/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -444,7 +444,9 @@ class MeshV2Service {
         }
 
         // Use server timestamp with fallback to current time
-        const serverTimestamp = nodeStatus.timestamp ? new Date(nodeStatus.timestamp).getTime() : Date.now();
+        const serverTimestamp = nodeStatus.timestamp ?
+            new Date(nodeStatus.timestamp).getTime() :
+            (log.warn('Mesh V2: Missing server timestamp, using client time'), Date.now());
 
         nodeStatus.data.forEach(item => {
             this.remoteData[nodeId][item.key] = {
@@ -929,7 +931,9 @@ class MeshV2Service {
                 if (!this.remoteData[status.nodeId]) {
                     this.remoteData[status.nodeId] = {};
                 }
-                const serverTimestamp = status.timestamp ? new Date(status.timestamp).getTime() : Date.now();
+                const serverTimestamp = status.timestamp ?
+                    new Date(status.timestamp).getTime() :
+                    (log.warn('Mesh V2: Missing server timestamp, using client time'), Date.now());
                 status.data.forEach(item => {
                     this.remoteData[status.nodeId][item.key] = {
                         value: item.value,

--- a/test/unit/mesh_service_v2.js
+++ b/test/unit/mesh_service_v2.js
@@ -160,7 +160,7 @@ test('MeshV2Service Batch Events', t => {
         st.end();
     });
 
-    t.test('processNextBroadcast processes events in one frame if their timing arrived and they are within 33ms', st => {
+    t.test('processNextBroadcast processes events in one frame if timing arrived and within 33ms', st => {
         const blocks = createMockBlocks();
         const service = new MeshV2Service(blocks, 'node1', 'domain1');
         service.groupId = 'group1';
@@ -215,7 +215,7 @@ test('MeshV2Service Batch Events', t => {
                 {name: 'e1', timestamp: '2025-12-30T00:00:00.000Z'}, // offset 0
                 {name: 'e2', timestamp: '2025-12-30T00:00:00.020Z'}, // offset 20
                 {name: 'e3', timestamp: '2025-12-30T00:00:00.040Z'}, // offset 40
-                {name: 'e4', timestamp: '2025-12-30T00:00:00.060Z'}  // offset 60
+                {name: 'e4', timestamp: '2025-12-30T00:00:00.060Z'} // offset 60
             ]
         };
 

--- a/test/unit/mesh_service_v2.js
+++ b/test/unit/mesh_service_v2.js
@@ -160,7 +160,7 @@ test('MeshV2Service Batch Events', t => {
         st.end();
     });
 
-    t.test('processNextBroadcast processes all events in one frame if their timing arrived', st => {
+    t.test('processNextBroadcast processes events in one frame if their timing arrived and they are within 33ms', st => {
         const blocks = createMockBlocks();
         const service = new MeshV2Service(blocks, 'node1', 'domain1');
         service.groupId = 'group1';
@@ -187,11 +187,100 @@ test('MeshV2Service Batch Events', t => {
             st.equal(service.pendingBroadcasts.length, 3);
 
             // Frame 1: Should broadcast all events because offsetMs (0) <= elapsedMs (0)
+            // and they are within 33ms window.
             service.processNextBroadcast();
             st.equal(broadcasted.length, 3);
             st.equal(broadcasted[0], 'e1');
             st.equal(broadcasted[1], 'e2');
             st.equal(broadcasted[2], 'e3');
+            st.equal(service.pendingBroadcasts.length, 0);
+        } finally {
+            Date.now = realDateNow;
+        }
+
+        st.end();
+    });
+
+    t.test('processNextBroadcast respects 33ms window when handling backlog', st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.groupId = 'group1';
+        const broadcasted = [];
+        service.broadcastEvent = event => broadcasted.push(event.name);
+
+        // Events spaced 20ms apart: 0ms, 20ms, 40ms, 60ms
+        const batchEvent = {
+            firedByNodeId: 'node2',
+            events: [
+                {name: 'e1', timestamp: '2025-12-30T00:00:00.000Z'}, // offset 0
+                {name: 'e2', timestamp: '2025-12-30T00:00:00.020Z'}, // offset 20
+                {name: 'e3', timestamp: '2025-12-30T00:00:00.040Z'}, // offset 40
+                {name: 'e4', timestamp: '2025-12-30T00:00:00.060Z'}  // offset 60
+            ]
+        };
+
+        const realDateNow = Date.now;
+        const startTime = 1000000;
+        let currentTime = startTime;
+        Date.now = () => currentTime;
+
+        try {
+            service.handleBatchEvent(batchEvent);
+            st.equal(service.pendingBroadcasts.length, 4);
+
+            // Simulation: Backlog exists. Current time is 100ms after start.
+            // elapsedMs = 100. All events are technically "due".
+            currentTime = startTime + 100;
+
+            // Frame 1: Should process e1, e2 (within 33ms of e1). e3 is at 40ms, so it's split.
+            service.processNextBroadcast();
+            st.equal(broadcasted.length, 2);
+            st.equal(broadcasted[0], 'e1');
+            st.equal(broadcasted[1], 'e2');
+            st.equal(service.pendingBroadcasts.length, 2);
+
+            // Frame 2: Should process e3, e4 (within 33ms of e3: 40 + 33 = 73).
+            service.processNextBroadcast();
+            st.equal(broadcasted.length, 4);
+            st.equal(broadcasted[2], 'e3');
+            st.equal(broadcasted[3], 'e4');
+            st.equal(service.pendingBroadcasts.length, 0);
+        } finally {
+            Date.now = realDateNow;
+        }
+
+        st.end();
+    });
+
+    t.test('processNextBroadcast processes many simultaneous events in one frame', st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.groupId = 'group1';
+        const broadcasted = [];
+        service.broadcastEvent = event => broadcasted.push(event.name);
+
+        // 50 events all with the same timestamp
+        const events = [];
+        for (let i = 0; i < 50; i++) {
+            events.push({name: `e${i}`, timestamp: '2025-12-30T00:00:00.000Z'});
+        }
+
+        const batchEvent = {
+            firedByNodeId: 'node2',
+            events: events
+        };
+
+        const realDateNow = Date.now;
+        const startTime = 1000000;
+        Date.now = () => startTime;
+
+        try {
+            service.handleBatchEvent(batchEvent);
+            st.equal(service.pendingBroadcasts.length, 50);
+
+            // All 50 should be processed in one frame because they all have offset 0
+            service.processNextBroadcast();
+            st.equal(broadcasted.length, 50);
             st.equal(service.pendingBroadcasts.length, 0);
         } finally {
             Date.now = realDateNow;

--- a/test/unit/mesh_service_v2_integration.js
+++ b/test/unit/mesh_service_v2_integration.js
@@ -109,6 +109,7 @@ test('MeshV2Service Integration: Splitting large batches', async t => {
     const service = new MeshV2Service(blocks, 'sender', 'domain');
     service.stopEventBatchTimer();
     service.groupId = 'group1';
+    service.MAX_EVENT_QUEUE_SIZE = 2000;
 
     let mutateCount = 0;
     service.client = {

--- a/test/unit/mesh_service_v2_order.js
+++ b/test/unit/mesh_service_v2_order.js
@@ -1,0 +1,121 @@
+const test = require('tap').test;
+const MeshV2Service = require('../../src/extensions/scratch3_mesh_v2/mesh-service');
+const {REPORT_DATA, FIRE_EVENTS} = require('../../src/extensions/scratch3_mesh_v2/gql-operations');
+
+const createMockBlocks = () => ({
+    runtime: {
+        sequencer: {},
+        emit: () => {},
+        on: () => {},
+        off: () => {},
+        getTargetForStage: () => ({
+            variables: {}
+        })
+    },
+    opcodeFunctions: {
+        event_broadcast: () => {}
+    }
+});
+
+test('MeshV2Service Data and Event Order', t => {
+    t.test('fireEventsBatch awaits lastDataSendPromise', async st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.stopEventBatchTimer();
+        service.groupId = 'group1';
+
+        let dataMutationStarted = false;
+        let dataMutationFinished = false;
+        let eventMutationStarted = false;
+
+        service.client = {
+            mutate: options => {
+                if (options.mutation === REPORT_DATA) {
+                    dataMutationStarted = true;
+                    return new Promise(resolve => {
+                        setTimeout(() => {
+                            dataMutationFinished = true;
+                            resolve({data: {reportDataByNode: {
+                                nodeId: 'node1',
+                                timestamp: new Date().toISOString(),
+                                data: []
+                            }}});
+                        }, 50); // Delay data mutation
+                    });
+                }
+                if (options.mutation === FIRE_EVENTS) {
+                    eventMutationStarted = true;
+                    st.ok(dataMutationStarted, 'Data mutation should have started');
+                    st.ok(dataMutationFinished, 'Data mutation should have finished before event mutation starts');
+                    return Promise.resolve({data: {fireEventsByNode: {}}});
+                }
+                return Promise.resolve({});
+            }
+        };
+
+        // 1. Send data
+        const dataPromise = service.sendData([{key: 'var1', value: '10'}]);
+        st.ok(service.lastDataSendPromise, 'lastDataSendPromise should be set');
+        
+        // 2. Fire event batch immediately (should wait for dataPromise)
+        const eventPromise = service.fireEventsBatch([{eventName: 'msg1', payload: '', firedAt: 't1'}]);
+
+        await Promise.all([dataPromise, eventPromise]);
+        
+        st.ok(dataMutationFinished, 'Data mutation finished');
+        st.ok(eventMutationStarted, 'Event mutation started');
+
+        st.end();
+    });
+
+    t.test('handleDataUpdate uses server timestamp', st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        
+        const serverTimestamp = '2025-12-30T12:34:56.789Z';
+        const expectedTime = new Date(serverTimestamp).getTime();
+        
+        const nodeStatus = {
+            nodeId: 'node2',
+            timestamp: serverTimestamp,
+            data: [
+                {key: 'var1', value: '100'}
+            ]
+        };
+        
+        service.handleDataUpdate(nodeStatus);
+        
+        st.equal(service.remoteData.node2.var1.value, '100');
+        st.equal(service.remoteData.node2.var1.timestamp, expectedTime, 'Should use server timestamp');
+        
+        st.end();
+    });
+
+    t.test('fireEventsBatch works without preceding data send', async st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.stopEventBatchTimer();
+        service.groupId = 'group1';
+
+        let eventMutationStarted = false;
+
+        service.client = {
+            mutate: options => {
+                if (options.mutation === FIRE_EVENTS) {
+                    eventMutationStarted = true;
+                    return Promise.resolve({data: {fireEventsByNode: {}}});
+                }
+                return Promise.resolve({});
+            }
+        };
+
+        // fireEventsBatch should work even if lastDataSendPromise is just Promise.resolve()
+        await service.fireEventsBatch([{eventName: 'msg1', payload: '', firedAt: 't1'}]);
+        
+        st.ok(eventMutationStarted, 'Event mutation started without data send');
+
+        st.end();
+    });
+
+    t.end();
+});

--- a/test/unit/mesh_service_v2_subscription.js
+++ b/test/unit/mesh_service_v2_subscription.js
@@ -29,7 +29,7 @@ test('MeshV2Service Subscription Integration', t => {
                 return {
                     subscribe: observer => {
                         subscriptionObserver = observer;
-                        return { unsubscribe: () => {} };
+                        return {unsubscribe: () => {}};
                     }
                 };
             }
@@ -52,7 +52,7 @@ test('MeshV2Service Subscription Integration', t => {
             subscribe: () => ({
                 subscribe: observer => {
                     subscriptionObserver = observer;
-                    return { unsubscribe: () => {} };
+                    return {unsubscribe: () => {}};
                 }
             })
         };
@@ -61,7 +61,7 @@ test('MeshV2Service Subscription Integration', t => {
 
         // Spy on handleDataUpdate
         let handleDataUpdateCalled = false;
-        service.handleDataUpdate = (payload) => {
+        service.handleDataUpdate = payload => {
             handleDataUpdateCalled = true;
             st.equal(payload.__typename, 'NodeStatus');
             st.equal(payload.nodeId, 'node2');
@@ -71,9 +71,11 @@ test('MeshV2Service Subscription Integration', t => {
         subscriptionObserver.next({
             data: {
                 onMessageInGroup: {
-                    __typename: 'NodeStatus',
-                    nodeId: 'node2',
-                    data: []
+                    nodeStatus: {
+                        __typename: 'NodeStatus',
+                        nodeId: 'node2',
+                        data: []
+                    }
                 }
             }
         });
@@ -92,7 +94,7 @@ test('MeshV2Service Subscription Integration', t => {
             subscribe: () => ({
                 subscribe: observer => {
                     subscriptionObserver = observer;
-                    return { unsubscribe: () => {} };
+                    return {unsubscribe: () => {}};
                 }
             })
         };
@@ -101,7 +103,7 @@ test('MeshV2Service Subscription Integration', t => {
 
         // Spy on handleBatchEvent
         let handleBatchEventCalled = false;
-        service.handleBatchEvent = (payload) => {
+        service.handleBatchEvent = payload => {
             handleBatchEventCalled = true;
             st.equal(payload.__typename, 'BatchEvent');
             st.equal(payload.firedByNodeId, 'node2');
@@ -111,9 +113,11 @@ test('MeshV2Service Subscription Integration', t => {
         subscriptionObserver.next({
             data: {
                 onMessageInGroup: {
-                    __typename: 'BatchEvent',
-                    firedByNodeId: 'node2',
-                    events: []
+                    batchEvent: {
+                        __typename: 'BatchEvent',
+                        firedByNodeId: 'node2',
+                        events: []
+                    }
                 }
             }
         });
@@ -132,7 +136,7 @@ test('MeshV2Service Subscription Integration', t => {
             subscribe: () => ({
                 subscribe: observer => {
                     subscriptionObserver = observer;
-                    return { unsubscribe: () => {} };
+                    return {unsubscribe: () => {}};
                 }
             })
         };
@@ -149,8 +153,10 @@ test('MeshV2Service Subscription Integration', t => {
         subscriptionObserver.next({
             data: {
                 onMessageInGroup: {
-                    __typename: 'GroupDissolvePayload',
-                    message: 'Bye'
+                    groupDissolve: {
+                        __typename: 'GroupDissolvePayload',
+                        message: 'Bye'
+                    }
                 }
             }
         });
@@ -170,7 +176,7 @@ test('MeshV2Service Subscription Integration', t => {
             subscribe: () => ({
                 subscribe: observer => {
                     subscriptionObserver = observer;
-                    return { unsubscribe: () => {} };
+                    return {unsubscribe: () => {}};
                 }
             })
         };
@@ -179,9 +185,15 @@ test('MeshV2Service Subscription Integration', t => {
 
         // Spies
         let anyCalled = false;
-        service.handleDataUpdate = () => { anyCalled = true; };
-        service.handleBatchEvent = () => { anyCalled = true; };
-        service.cleanupAndDisconnect = () => { anyCalled = true; };
+        service.handleDataUpdate = () => {
+            anyCalled = true;
+        };
+        service.handleBatchEvent = () => {
+            anyCalled = true;
+        };
+        service.cleanupAndDisconnect = () => {
+            anyCalled = true;
+        };
 
         // Simulate unknown message
         subscriptionObserver.next({

--- a/test/unit/mesh_service_v2_subscription.js
+++ b/test/unit/mesh_service_v2_subscription.js
@@ -1,0 +1,200 @@
+const test = require('tap').test;
+const MeshV2Service = require('../../src/extensions/scratch3_mesh_v2/mesh-service');
+const {ON_MESSAGE_IN_GROUP} = require('../../src/extensions/scratch3_mesh_v2/gql-operations');
+
+const createMockBlocks = () => ({
+    runtime: {
+        sequencer: {},
+        emit: () => {},
+        on: () => {},
+        off: () => {}
+    },
+    opcodeFunctions: {
+        event_broadcast: () => {}
+    }
+});
+
+test('MeshV2Service Subscription Integration', t => {
+    t.test('startSubscriptions subscribes to ON_MESSAGE_IN_GROUP', st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.groupId = 'group1';
+
+        let subscribedQuery = null;
+        let subscriptionObserver = null;
+
+        service.client = {
+            subscribe: ({query}) => {
+                subscribedQuery = query;
+                return {
+                    subscribe: observer => {
+                        subscriptionObserver = observer;
+                        return { unsubscribe: () => {} };
+                    }
+                };
+            }
+        };
+
+        service.startSubscriptions();
+
+        st.equal(subscribedQuery, ON_MESSAGE_IN_GROUP, 'Should subscribe to ON_MESSAGE_IN_GROUP');
+        st.ok(subscriptionObserver, 'Should verify observer is attached');
+        st.end();
+    });
+
+    t.test('Routes NodeStatus to handleDataUpdate', st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.groupId = 'group1';
+
+        let subscriptionObserver = null;
+        service.client = {
+            subscribe: () => ({
+                subscribe: observer => {
+                    subscriptionObserver = observer;
+                    return { unsubscribe: () => {} };
+                }
+            })
+        };
+
+        service.startSubscriptions();
+
+        // Spy on handleDataUpdate
+        let handleDataUpdateCalled = false;
+        service.handleDataUpdate = (payload) => {
+            handleDataUpdateCalled = true;
+            st.equal(payload.__typename, 'NodeStatus');
+            st.equal(payload.nodeId, 'node2');
+        };
+
+        // Simulate incoming message
+        subscriptionObserver.next({
+            data: {
+                onMessageInGroup: {
+                    __typename: 'NodeStatus',
+                    nodeId: 'node2',
+                    data: []
+                }
+            }
+        });
+
+        st.ok(handleDataUpdateCalled, 'Should call handleDataUpdate');
+        st.end();
+    });
+
+    t.test('Routes BatchEvent to handleBatchEvent', st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.groupId = 'group1';
+
+        let subscriptionObserver = null;
+        service.client = {
+            subscribe: () => ({
+                subscribe: observer => {
+                    subscriptionObserver = observer;
+                    return { unsubscribe: () => {} };
+                }
+            })
+        };
+
+        service.startSubscriptions();
+
+        // Spy on handleBatchEvent
+        let handleBatchEventCalled = false;
+        service.handleBatchEvent = (payload) => {
+            handleBatchEventCalled = true;
+            st.equal(payload.__typename, 'BatchEvent');
+            st.equal(payload.firedByNodeId, 'node2');
+        };
+
+        // Simulate incoming message
+        subscriptionObserver.next({
+            data: {
+                onMessageInGroup: {
+                    __typename: 'BatchEvent',
+                    firedByNodeId: 'node2',
+                    events: []
+                }
+            }
+        });
+
+        st.ok(handleBatchEventCalled, 'Should call handleBatchEvent');
+        st.end();
+    });
+
+    t.test('Routes GroupDissolvePayload to cleanupAndDisconnect', st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.groupId = 'group1';
+
+        let subscriptionObserver = null;
+        service.client = {
+            subscribe: () => ({
+                subscribe: observer => {
+                    subscriptionObserver = observer;
+                    return { unsubscribe: () => {} };
+                }
+            })
+        };
+
+        service.startSubscriptions();
+
+        // Spy on cleanupAndDisconnect
+        let cleanupCalled = false;
+        service.cleanupAndDisconnect = () => {
+            cleanupCalled = true;
+        };
+
+        // Simulate incoming message
+        subscriptionObserver.next({
+            data: {
+                onMessageInGroup: {
+                    __typename: 'GroupDissolvePayload',
+                    message: 'Bye'
+                }
+            }
+        });
+
+        st.ok(cleanupCalled, 'Should call cleanupAndDisconnect');
+        st.equal(service.costTracking.dissolveReceived, 1, 'Should increment dissolve tracking');
+        st.end();
+    });
+
+    t.test('Ignores unknown types', st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.groupId = 'group1';
+
+        let subscriptionObserver = null;
+        service.client = {
+            subscribe: () => ({
+                subscribe: observer => {
+                    subscriptionObserver = observer;
+                    return { unsubscribe: () => {} };
+                }
+            })
+        };
+
+        service.startSubscriptions();
+
+        // Spies
+        let anyCalled = false;
+        service.handleDataUpdate = () => { anyCalled = true; };
+        service.handleBatchEvent = () => { anyCalled = true; };
+        service.cleanupAndDisconnect = () => { anyCalled = true; };
+
+        // Simulate unknown message
+        subscriptionObserver.next({
+            data: {
+                onMessageInGroup: {
+                    __typename: 'UnknownType'
+                }
+            }
+        });
+
+        st.notOk(anyCalled, 'Should not call any handler for unknown type');
+        st.end();
+    });
+
+    t.end();
+});

--- a/test/unit/mesh_service_v2_timestamp.js
+++ b/test/unit/mesh_service_v2_timestamp.js
@@ -35,33 +35,36 @@ test('MeshV2Service Timestamp-based getRemoteVariable', t => {
         st.end();
     });
 
-    t.test('handleDataUpdate should add timestamp', st => {
+    t.test('handleDataUpdate should add timestamp from nodeStatus', st => {
+        const serverTimestamp = new Date().toISOString();
+        const expectedTimestamp = new Date(serverTimestamp).getTime();
         const nodeStatus = {
             nodeId: 'node4',
+            timestamp: serverTimestamp,
             data: [
                 {key: 'var1', value: '100'}
             ]
         };
 
-        const beforeUpdate = Date.now();
         service.handleDataUpdate(nodeStatus);
-        const afterUpdate = Date.now();
 
         st.ok(service.remoteData.node4, 'Node 4 should be added');
         st.ok(service.remoteData.node4.var1, 'var1 should be added');
         st.equal(service.remoteData.node4.var1.value, '100');
-        st.ok(service.remoteData.node4.var1.timestamp >= beforeUpdate);
-        st.ok(service.remoteData.node4.var1.timestamp <= afterUpdate);
+        st.equal(service.remoteData.node4.var1.timestamp, expectedTimestamp, 'Should use server timestamp');
         st.end();
     });
 
-    t.test('fetchAllNodesData should add timestamp', async st => {
+    t.test('fetchAllNodesData should add timestamp from status', async st => {
+        const serverTimestamp = new Date().toISOString();
+        const expectedTimestamp = new Date(serverTimestamp).getTime();
         service.client = {
             query: () => Promise.resolve({
                 data: {
                     listGroupStatuses: [
                         {
                             nodeId: 'node5',
+                            timestamp: serverTimestamp,
                             data: [{key: 'var2', value: '200'}]
                         }
                     ]
@@ -69,14 +72,11 @@ test('MeshV2Service Timestamp-based getRemoteVariable', t => {
             })
         };
 
-        const beforeFetch = Date.now();
         await service.fetchAllNodesData();
-        const afterFetch = Date.now();
 
         st.ok(service.remoteData.node5, 'Node 5 should be added');
         st.equal(service.remoteData.node5.var2.value, '200');
-        st.ok(service.remoteData.node5.var2.timestamp >= beforeFetch);
-        st.ok(service.remoteData.node5.var2.timestamp <= afterFetch);
+        st.equal(service.remoteData.node5.var2.timestamp, expectedTimestamp, 'Should use server timestamp');
         st.end();
     });
 


### PR DESCRIPTION
## Summary
This PR optimizes the Mesh V2 event queue to prevent memory bloating and improve performance when a large number of events are fired (e.g., in a 'forever' loop).

## Changes
- **Sender-side (Deduplication + Size Limit)**:
    - Added `MAX_EVENT_QUEUE_SIZE` (default 100) to limit the number of queued events.
    - Implemented deduplication: if an event with the same name and payload is already in the queue, it's skipped.
    - Implemented FIFO: if the queue is full, the oldest event is dropped.
    - Added statistics tracking for skipped and dropped events, reported every 10 seconds and upon cleanup.
- **Receiver-side (Batch Processing)**:
    - Updated `processNextBroadcast` to process all events whose timing has arrived in a single frame, instead of just one per frame. This significantly improves responsiveness when receiving many events.

## Test Coverage
- Updated `test/unit/mesh_service_v2.js`:
    - Added `fireEvent deduplicates events` test.
    - Added `fireEvent respects MAX_EVENT_QUEUE_SIZE (FIFO)` test.
    - Added `reportEventStatsIfNeeded logs stats every 10s` test.
    - Added `cleanup reports final stats` test.
    - Updated `processNextBroadcast` test to verify batch processing.
- Updated `test/unit/mesh_service_v2_integration.js`:
    - Increased queue size in 'Splitting large batches' test to accommodate 1500 events.

Addressing smalruby/smalruby3-gui#500

🤖 Generated with [Gemini Code](https://gemini.google.com/code)

Co-Authored-By: Gemini <noreply@google.com>