### PR TITLE
feat: meshV2: Create broadcast message locally if it doesn't exist when received from mesh

### DIFF
--- a/src/engine/variable.js
+++ b/src/engine/variable.js
@@ -19,6 +19,7 @@ class Variable {
         this.name = name;
         this.type = type;
         this.isCloud = isCloud;
+        this.isPersistent = false;
         switch (this.type) {
         case Variable.SCALAR_TYPE:
             this.value = 0;

--- a/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -615,9 +615,18 @@ class MeshV2Service {
     broadcastEvent (event) {
         log.info(`Mesh V2: Executing broadcastEvent for: ${event.name}`);
         try {
+            const stage = this.runtime.getTargetForStage();
+            let broadcastVar = stage.lookupBroadcastMsg(null, event.name);
+            if (!broadcastVar) {
+                log.info(`Mesh V2: Creating missing broadcast message: ${event.name}`);
+                stage.createVariable(null, event.name, Variable.BROADCAST_MESSAGE_TYPE);
+                broadcastVar = stage.lookupBroadcastMsg(null, event.name);
+                this.runtime.requestBlocksUpdate();
+            }
+
             const args = {
                 BROADCAST_OPTION: {
-                    id: null,
+                    id: broadcastVar ? broadcastVar.id : null,
                     name: event.name
                 }
             };

--- a/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -616,11 +616,11 @@ class MeshV2Service {
         log.info(`Mesh V2: Executing broadcastEvent for: ${event.name}`);
         try {
             const stage = this.runtime.getTargetForStage();
-            let broadcastVar = stage.lookupBroadcastMsg(null, event.name);
+            let broadcastVar = stage.lookupBroadcastByInputValue(event.name);
             if (!broadcastVar) {
                 log.info(`Mesh V2: Creating missing broadcast message: ${event.name}`);
                 stage.createVariable(null, event.name, Variable.BROADCAST_MESSAGE_TYPE);
-                broadcastVar = stage.lookupBroadcastMsg(null, event.name);
+                broadcastVar = stage.lookupBroadcastByInputValue(event.name);
                 if (broadcastVar) {
                     broadcastVar.isPersistent = true;
                 }
@@ -630,7 +630,7 @@ class MeshV2Service {
             const args = {
                 BROADCAST_OPTION: {
                     id: broadcastVar ? broadcastVar.id : null,
-                    name: event.name
+                    name: broadcastVar ? broadcastVar.name : event.name
                 }
             };
             const util = BlockUtility.lastInstance();

--- a/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -621,6 +621,9 @@ class MeshV2Service {
                 log.info(`Mesh V2: Creating missing broadcast message: ${event.name}`);
                 stage.createVariable(null, event.name, Variable.BROADCAST_MESSAGE_TYPE);
                 broadcastVar = stage.lookupBroadcastMsg(null, event.name);
+                if (broadcastVar) {
+                    broadcastVar.isPersistent = true;
+                }
                 this.runtime.requestBlocksUpdate();
             }
 

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1400,6 +1400,9 @@ class VirtualMachine extends EventEmitter {
         // Anything left in messageIds is not referenced by a block, so delete it.
         for (let i = 0; i < messageIds.length; i++) {
             const id = messageIds[i];
+            if (this.runtime.getTargetForStage().variables[id].isPersistent) {
+                continue;
+            }
             delete this.runtime.getTargetForStage().variables[id];
         }
         const globalVarMap = Object.assign({}, this.runtime.getTargetForStage().variables);

--- a/test/unit/mesh_service_v2_broadcast_creation.js
+++ b/test/unit/mesh_service_v2_broadcast_creation.js
@@ -1,0 +1,111 @@
+const test = require('tap').test;
+const MeshV2Service = require('../../src/extensions/scratch3_mesh_v2/mesh-service');
+const BlockUtility = require('../../src/engine/block-utility');
+const Variable = require('../../src/engine/variable');
+
+const createMockBlocks = stage => ({
+    runtime: {
+        sequencer: {},
+        emit: () => {},
+        on: () => {},
+        off: () => {},
+        getTargetForStage: () => stage,
+        requestBlocksUpdate: () => {}
+    },
+    opcodeFunctions: {
+        event_broadcast: () => {}
+    }
+});
+
+const createMockStage = () => ({
+    variables: {},
+    lookupBroadcastMsg: function (id, name) {
+        for (const varId in this.variables) {
+            const v = this.variables[varId];
+            if (v.type === Variable.BROADCAST_MESSAGE_TYPE && v.name === name) {
+                return v;
+            }
+        }
+        return null;
+    },
+    createVariable: function (id, name, type) {
+        const varId = id || `id-${name}`;
+        this.variables[varId] = new Variable(varId, name, type);
+    }
+});
+
+// Mock BlockUtility.lastInstance()
+const originalLastInstance = BlockUtility.lastInstance;
+const mockUtil = {
+    sequencer: {}
+};
+BlockUtility.lastInstance = () => mockUtil;
+
+test('MeshV2Service Broadcast Creation', t => {
+    t.test('broadcastEvent creates missing broadcast message', st => {
+        const stage = createMockStage();
+        const blocks = createMockBlocks(stage);
+        let broadcastArgs = null;
+        blocks.opcodeFunctions.event_broadcast = args => {
+            broadcastArgs = args;
+        };
+
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.groupId = 'group1';
+
+        const event = {
+            name: 'new message',
+            firedByNodeId: 'node2'
+        };
+
+        service.broadcastEvent(event);
+
+        // Check if message was created
+        const broadcastVar = stage.lookupBroadcastMsg(null, 'new message');
+        st.ok(broadcastVar, 'Broadcast message should be created');
+        st.equal(broadcastVar.name, 'new message');
+        st.equal(broadcastVar.type, Variable.BROADCAST_MESSAGE_TYPE);
+
+        // Check if opcode was called with the new ID
+        st.ok(broadcastArgs, 'event_broadcast should be called');
+        st.equal(broadcastArgs.BROADCAST_OPTION.name, 'new message');
+        st.equal(broadcastArgs.BROADCAST_OPTION.id, broadcastVar.id);
+
+        st.end();
+    });
+
+    t.test('broadcastEvent uses existing broadcast message', st => {
+        const stage = createMockStage();
+        const existingVar = new Variable('existing-id', 'existing message', Variable.BROADCAST_MESSAGE_TYPE);
+        stage.variables['existing-id'] = existingVar;
+
+        const blocks = createMockBlocks(stage);
+        let broadcastArgs = null;
+        blocks.opcodeFunctions.event_broadcast = args => {
+            broadcastArgs = args;
+        };
+
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.groupId = 'group1';
+
+        const event = {
+            name: 'existing message',
+            firedByNodeId: 'node2'
+        };
+
+        service.broadcastEvent(event);
+
+        // Check if opcode was called with the existing ID
+        st.ok(broadcastArgs, 'event_broadcast should be called');
+        st.equal(broadcastArgs.BROADCAST_OPTION.name, 'existing message');
+        st.equal(broadcastArgs.BROADCAST_OPTION.id, 'existing-id');
+
+        st.end();
+    });
+
+    t.tearDown(() => {
+        BlockUtility.lastInstance = originalLastInstance;
+    });
+
+    t.end();
+});

--- a/test/unit/mesh_service_v2_broadcast_creation.js
+++ b/test/unit/mesh_service_v2_broadcast_creation.js
@@ -65,6 +65,7 @@ test('MeshV2Service Broadcast Creation', t => {
         st.ok(broadcastVar, 'Broadcast message should be created');
         st.equal(broadcastVar.name, 'new message');
         st.equal(broadcastVar.type, Variable.BROADCAST_MESSAGE_TYPE);
+        st.equal(broadcastVar.isPersistent, true, 'Broadcast message should be persistent');
 
         // Check if opcode was called with the new ID
         st.ok(broadcastArgs, 'event_broadcast should be called');

--- a/test/unit/mesh_service_v2_broadcast_creation.js
+++ b/test/unit/mesh_service_v2_broadcast_creation.js
@@ -28,6 +28,15 @@ const createMockStage = () => ({
         }
         return null;
     },
+    lookupBroadcastByInputValue: function (name) {
+        for (const varId in this.variables) {
+            const v = this.variables[varId];
+            if (v.type === Variable.BROADCAST_MESSAGE_TYPE && v.name.toLowerCase() === name.toLowerCase()) {
+                return v;
+            }
+        }
+        return null;
+    },
     createVariable: function (id, name, type) {
         const varId = id || `id-${name}`;
         this.variables[varId] = new Variable(varId, name, type);
@@ -61,7 +70,7 @@ test('MeshV2Service Broadcast Creation', t => {
         service.broadcastEvent(event);
 
         // Check if message was created
-        const broadcastVar = stage.lookupBroadcastMsg(null, 'new message');
+        const broadcastVar = stage.lookupBroadcastByInputValue('new message');
         st.ok(broadcastVar, 'Broadcast message should be created');
         st.equal(broadcastVar.name, 'new message');
         st.equal(broadcastVar.type, Variable.BROADCAST_MESSAGE_TYPE);
@@ -75,9 +84,9 @@ test('MeshV2Service Broadcast Creation', t => {
         st.end();
     });
 
-    t.test('broadcastEvent uses existing broadcast message', st => {
+    t.test('broadcastEvent uses existing broadcast message (case-insensitive)', st => {
         const stage = createMockStage();
-        const existingVar = new Variable('existing-id', 'existing message', Variable.BROADCAST_MESSAGE_TYPE);
+        const existingVar = new Variable('existing-id', 'Existing Message', Variable.BROADCAST_MESSAGE_TYPE);
         stage.variables['existing-id'] = existingVar;
 
         const blocks = createMockBlocks(stage);
@@ -96,10 +105,11 @@ test('MeshV2Service Broadcast Creation', t => {
 
         service.broadcastEvent(event);
 
-        // Check if opcode was called with the existing ID
+        // Check if opcode was called with the existing ID and canonical name
         st.ok(broadcastArgs, 'event_broadcast should be called');
-        st.equal(broadcastArgs.BROADCAST_OPTION.name, 'existing message');
-        st.equal(broadcastArgs.BROADCAST_OPTION.id, 'existing-id');
+        st.equal(broadcastArgs.BROADCAST_OPTION.id, 'existing-id', 'Should use existing variable ID');
+        st.equal(broadcastArgs.BROADCAST_OPTION.name, 'Existing Message', 'Should use canonical name');
+        st.equal(Object.keys(stage.variables).length, 1, 'Should not create duplicate variable');
 
         st.end();
     });

--- a/test/unit/mesh_service_v2_integration.js
+++ b/test/unit/mesh_service_v2_integration.js
@@ -12,7 +12,12 @@ const createMockBlocks = broadcastCallback => ({
         sequencer: {},
         emit: () => {},
         on: () => {},
-        off: () => {}
+        off: () => {},
+        getTargetForStage: () => ({
+            lookupBroadcastMsg: (id, name) => ({id: `id-${name}`, name: name}),
+            createVariable: () => {}
+        }),
+        requestBlocksUpdate: () => {}
     },
     opcodeFunctions: {
         event_broadcast: args => {

--- a/test/unit/mesh_service_v2_integration.js
+++ b/test/unit/mesh_service_v2_integration.js
@@ -15,6 +15,7 @@ const createMockBlocks = broadcastCallback => ({
         off: () => {},
         getTargetForStage: () => ({
             lookupBroadcastMsg: (id, name) => ({id: `id-${name}`, name: name}),
+            lookupBroadcastByInputValue: name => ({id: `id-${name}`, name: name}),
             createVariable: () => {}
         }),
         requestBlocksUpdate: () => {}


### PR DESCRIPTION
### Summary
This PR implements automatic creation of broadcast messages when they are received from the mesh network but do not exist in the local project.

### Changes
- Modified `broadcastEvent` in `MeshV2Service` to check for message existence on the stage.
- If missing, the message is created using `stage.createVariable` with `Variable.BROADCAST_MESSAGE_TYPE`.
- `this.runtime.requestBlocksUpdate()` is called to ensure the new message appears in block dropdowns immediately.
- The broadcast opcode is triggered using the correct message ID.
- Added a new unit test: `test/unit/mesh_service_v2_broadcast_creation.js`.
- Updated mock in `test/unit/mesh_service_v2_integration.js` to support the new logic.

### Verification Results
- Unit tests pass: `npm run tap:unit` (Specifically verified the new test file and integration test).
- Lint passes: `npm run lint`.

Fixes https://github.com/smalruby/scratch-vm/issues/84