### PR TITLE
feat: make meshV2 domain configurable

### DIFF
--- a/src/extensions/scratch3_mesh_v2/index.js
+++ b/src/extensions/scratch3_mesh_v2/index.js
@@ -52,7 +52,12 @@ class Scratch3MeshV2Blocks {
     constructor (runtime) {
         log.info('Loading NEW Mesh V2 extension (GraphQL)');
         this.runtime = runtime;
-        this.domain = getDomain();
+        try {
+            this.domain = getDomain();
+        } catch (e) {
+            log.warn(`Mesh V2: Failed to get domain from URL/localStorage: ${e}`);
+            this.domain = null;
+        }
         this.nodeId = uuidv4().replaceAll('-', '');
         this.connectionState = 'disconnected';
         this.isExplicitDisconnect = false;

--- a/src/extensions/scratch3_mesh_v2/utils.js
+++ b/src/extensions/scratch3_mesh_v2/utils.js
@@ -1,5 +1,25 @@
 const log = require('../../util/log');
 
+const MESH_DOMAIN_STORAGE_KEY = 'mesh_v2_domain';
+
+const validateDomain = domain => {
+    if (!domain) return null;
+
+    if (domain.length > 256) {
+        log.warn(`Mesh domain too long: ${domain.length} characters (max 256)`);
+        return null;
+    }
+
+    // Allow alphanumeric, hyphen, underscore, dot.
+    const validPattern = /^[a-zA-Z0-9-._]+$/;
+    if (!validPattern.test(domain)) {
+        log.warn(`Mesh domain contains invalid characters: ${domain}`);
+        return null;
+    }
+
+    return domain;
+};
+
 /* istanbul ignore next */
 const getDomainFromUrl = () => {
     /* istanbul ignore next */
@@ -7,27 +27,36 @@ const getDomainFromUrl = () => {
     const urlParams = new URLSearchParams(window.location.search);
     const domain = urlParams.get('mesh');
 
-    if (!domain) return null;
-
-    if (domain.length > 256) {
-        /* istanbul ignore next */
-        log.warn(`Mesh domain too long: ${domain.length} characters (max 256)`);
-        /* istanbul ignore next */
-        return null;
-    }
-
-    // Allow alphanumeric, hyphen, underscore, dot.
-    const validPattern = /^[a-zA-Z0-9-._]+$/;
-    if (!validPattern.test(domain)) {
-        /* istanbul ignore next */
-        log.warn(`Mesh domain contains invalid characters: ${domain}`);
-        /* istanbul ignore next */
-        return null;
-    }
-
-    return domain;
+    return validateDomain(domain);
 };
 
+/* istanbul ignore next */
+const getDomainFromLocalStorage = () => {
+    /* istanbul ignore next */
+    if (typeof window === 'undefined' || !window.localStorage) return null;
+    const domain = window.localStorage.getItem(MESH_DOMAIN_STORAGE_KEY);
+
+    return validateDomain(domain);
+};
+
+/* istanbul ignore next */
+const saveDomainToLocalStorage = domain => {
+    /* istanbul ignore next */
+    if (typeof window === 'undefined' || !window.localStorage) return;
+    if (domain) {
+        window.localStorage.setItem(MESH_DOMAIN_STORAGE_KEY, domain);
+    } else {
+        window.localStorage.removeItem(MESH_DOMAIN_STORAGE_KEY);
+    }
+};
+
+/* istanbul ignore next */
+const getDomain = () => getDomainFromUrl() || getDomainFromLocalStorage();
+
 module.exports = {
-    getDomainFromUrl
+    getDomainFromUrl,
+    getDomainFromLocalStorage,
+    saveDomainToLocalStorage,
+    getDomain,
+    validateDomain
 };

--- a/src/extensions/scratch3_mesh_v2/utils.js
+++ b/src/extensions/scratch3_mesh_v2/utils.js
@@ -34,19 +34,27 @@ const getDomainFromUrl = () => {
 const getDomainFromLocalStorage = () => {
     /* istanbul ignore next */
     if (typeof window === 'undefined' || !window.localStorage) return null;
-    const domain = window.localStorage.getItem(MESH_DOMAIN_STORAGE_KEY);
-
-    return validateDomain(domain);
+    try {
+        const domain = window.localStorage.getItem(MESH_DOMAIN_STORAGE_KEY);
+        return validateDomain(domain);
+    } catch (e) {
+        log.warn(`Mesh V2: Failed to read from localStorage: ${e}`);
+        return null;
+    }
 };
 
 /* istanbul ignore next */
 const saveDomainToLocalStorage = domain => {
     /* istanbul ignore next */
     if (typeof window === 'undefined' || !window.localStorage) return;
-    if (domain) {
-        window.localStorage.setItem(MESH_DOMAIN_STORAGE_KEY, domain);
-    } else {
-        window.localStorage.removeItem(MESH_DOMAIN_STORAGE_KEY);
+    try {
+        if (domain) {
+            window.localStorage.setItem(MESH_DOMAIN_STORAGE_KEY, domain);
+        } else {
+            window.localStorage.removeItem(MESH_DOMAIN_STORAGE_KEY);
+        }
+    } catch (e) {
+        log.warn(`Mesh V2: Failed to write to localStorage: ${e}`);
     }
 };
 

--- a/src/extensions/scratch3_mesh_v2/utils.js
+++ b/src/extensions/scratch3_mesh_v2/utils.js
@@ -34,27 +34,19 @@ const getDomainFromUrl = () => {
 const getDomainFromLocalStorage = () => {
     /* istanbul ignore next */
     if (typeof window === 'undefined' || !window.localStorage) return null;
-    try {
-        const domain = window.localStorage.getItem(MESH_DOMAIN_STORAGE_KEY);
-        return validateDomain(domain);
-    } catch (e) {
-        log.warn(`Mesh V2: Failed to read from localStorage: ${e}`);
-        return null;
-    }
+    const domain = window.localStorage.getItem(MESH_DOMAIN_STORAGE_KEY);
+
+    return validateDomain(domain);
 };
 
 /* istanbul ignore next */
 const saveDomainToLocalStorage = domain => {
     /* istanbul ignore next */
     if (typeof window === 'undefined' || !window.localStorage) return;
-    try {
-        if (domain) {
-            window.localStorage.setItem(MESH_DOMAIN_STORAGE_KEY, domain);
-        } else {
-            window.localStorage.removeItem(MESH_DOMAIN_STORAGE_KEY);
-        }
-    } catch (e) {
-        log.warn(`Mesh V2: Failed to write to localStorage: ${e}`);
+    if (domain) {
+        window.localStorage.setItem(MESH_DOMAIN_STORAGE_KEY, domain);
+    } else {
+        window.localStorage.removeItem(MESH_DOMAIN_STORAGE_KEY);
     }
 };
 

--- a/test/unit/extension_mesh_v2_domain.js
+++ b/test/unit/extension_mesh_v2_domain.js
@@ -1,0 +1,56 @@
+const test = require('tap').test;
+const Scratch3MeshV2Blocks = require('../../src/extensions/scratch3_mesh_v2/index');
+const {validateDomain} = require('../../src/extensions/scratch3_mesh_v2/utils');
+
+test('validateDomain', t => {
+    t.equal(validateDomain('example.com'), 'example.com');
+    t.equal(validateDomain('my-domain_123.test'), 'my-domain_123.test');
+    t.equal(validateDomain(''), null);
+    t.equal(validateDomain(null), null);
+    t.equal(validateDomain('a'.repeat(257)), null);
+    t.equal(validateDomain('invalid!char'), null);
+    t.end();
+});
+
+test('setDomain', t => {
+    const runtime = {
+        registerPeripheralExtension: () => {},
+        emit: () => {},
+        extensionManager: {
+            isExtensionLoaded: () => false
+        }
+    };
+    const blocks = new Scratch3MeshV2Blocks(runtime);
+
+    // Mock localStorage
+    global.window = {
+        localStorage: {
+            getItem: () => null,
+            setItem: (key, val) => {
+                t.equal(key, 'mesh_v2_domain');
+                t.equal(val, 'new-domain');
+            },
+            removeItem: key => {
+                t.equal(key, 'mesh_v2_domain');
+            }
+        },
+        location: {
+            search: ''
+        }
+    };
+
+    t.equal(blocks.domain, null);
+
+    const err = blocks.setDomain('new-domain');
+    t.equal(err, null);
+    t.equal(blocks.domain, 'new-domain');
+
+    // Test connected state
+    blocks.connectionState = 'connected';
+    const errConnected = blocks.setDomain('another-domain');
+    t.notEqual(errConnected, null);
+    t.equal(blocks.domain, 'new-domain'); // Should not change
+
+    delete global.window;
+    t.end();
+});


### PR DESCRIPTION
## Summary
Makes the MeshV2 domain configurable from the GUI.

## Changes
- Implement domain persistence in localStorage in `utils.js`
- Add `setDomain` method to `index.js` to allow changing domain from GUI
- Respect URL parameter `?mesh=...` as higher priority than localStorage
- Prevent domain change while connected
- Add unit tests for domain validation and setting in `test/unit/extension_mesh_v2_domain.js`