### PR TITLE
feat: implement polling fallback for event communication

### DIFF
--- a/src/extensions/scratch3_mesh_v2/gql-operations.js
+++ b/src/extensions/scratch3_mesh_v2/gql-operations.js
@@ -50,7 +50,6 @@ const JOIN_GROUP = gql`
       name
       groupId
       domain
-      createdAt
       expiresAt
       heartbeatIntervalSeconds
       useWebSocket
@@ -89,7 +88,6 @@ const RENEW_HEARTBEAT = gql`
     renewHeartbeat(groupId: $groupId, domain: $domain, hostId: $hostId) {
       groupId
       domain
-      createdAt
       expiresAt
       heartbeatIntervalSeconds
     }
@@ -102,7 +100,6 @@ const SEND_MEMBER_HEARTBEAT = gql`
       nodeId
       groupId
       domain
-      createdAt
       expiresAt
       heartbeatIntervalSeconds
     }

--- a/src/extensions/scratch3_mesh_v2/gql-operations.js
+++ b/src/extensions/scratch3_mesh_v2/gql-operations.js
@@ -9,7 +9,6 @@ const LIST_GROUPS_BY_DOMAIN = gql`
       fullId
       name
       hostId
-      createdAt
       expiresAt
     }
   }
@@ -34,7 +33,6 @@ const CREATE_GROUP = gql`
       fullId
       name
       hostId
-      createdAt
       expiresAt
       heartbeatIntervalSeconds
       useWebSocket

--- a/src/extensions/scratch3_mesh_v2/gql-operations.js
+++ b/src/extensions/scratch3_mesh_v2/gql-operations.js
@@ -162,7 +162,7 @@ const RECORD_EVENTS = gql`
 `;
 
 const GET_EVENTS_SINCE = gql`
-  query GetEventsSince($groupId: ID!, $domain: String!, $since: AWSDateTime!) {
+  query GetEventsSince($groupId: ID!, $domain: String!, $since: String!) {
     getEventsSince(groupId: $groupId, domain: $domain, since: $since) {
       name
       firedByNodeId

--- a/src/extensions/scratch3_mesh_v2/gql-operations.js
+++ b/src/extensions/scratch3_mesh_v2/gql-operations.js
@@ -22,8 +22,13 @@ const CREATE_DOMAIN = gql`
 `;
 
 const CREATE_GROUP = gql`
-  mutation CreateGroup($name: String!, $hostId: ID!, $domain: String!, $maxConnectionTimeSeconds: Int) {
-    createGroup(name: $name, hostId: $hostId, domain: $domain, maxConnectionTimeSeconds: $maxConnectionTimeSeconds) {
+  mutation CreateGroup(
+    $name: String!, $hostId: ID!, $domain: String!, $maxConnectionTimeSeconds: Int, $useWebSocket: Boolean!
+  ) {
+    createGroup(
+      name: $name, hostId: $hostId, domain: $domain,
+      maxConnectionTimeSeconds: $maxConnectionTimeSeconds, useWebSocket: $useWebSocket
+    ) {
       id
       domain
       fullId
@@ -32,6 +37,8 @@ const CREATE_GROUP = gql`
       createdAt
       expiresAt
       heartbeatIntervalSeconds
+      useWebSocket
+      pollingIntervalSeconds
     }
   }
 `;
@@ -45,6 +52,8 @@ const JOIN_GROUP = gql`
       domain
       expiresAt
       heartbeatIntervalSeconds
+      useWebSocket
+      pollingIntervalSeconds
     }
   }
 `;
@@ -139,6 +148,32 @@ const FIRE_EVENTS = gql`
   }
 `;
 
+const RECORD_EVENTS = gql`
+  mutation RecordEventsByNode($groupId: ID!, $domain: String!, $nodeId: ID!, $events: [EventInput!]!) {
+    recordEventsByNode(
+      groupId: $groupId, domain: $domain, nodeId: $nodeId, events: $events
+    ) {
+      groupId
+      domain
+      recordedCount
+      nextSince
+    }
+  }
+`;
+
+const GET_EVENTS_SINCE = gql`
+  query GetEventsSince($groupId: ID!, $domain: String!, $since: AWSDateTime!) {
+    getEventsSince(groupId: $groupId, domain: $domain, since: $since) {
+      name
+      firedByNodeId
+      groupId
+      domain
+      payload
+      timestamp
+    }
+  }
+`;
+
 const ON_MESSAGE_IN_GROUP = gql`
   subscription OnMessageInGroup($groupId: ID!, $domain: String!) {
     onMessageInGroup(groupId: $groupId, domain: $domain) {
@@ -203,6 +238,8 @@ module.exports = {
     SEND_MEMBER_HEARTBEAT,
     REPORT_DATA,
     FIRE_EVENTS,
+    RECORD_EVENTS,
+    GET_EVENTS_SINCE,
     ON_MESSAGE_IN_GROUP,
     LIST_GROUP_STATUSES
 };

--- a/src/extensions/scratch3_mesh_v2/gql-operations.js
+++ b/src/extensions/scratch3_mesh_v2/gql-operations.js
@@ -170,6 +170,7 @@ const GET_EVENTS_SINCE = gql`
       domain
       payload
       timestamp
+      cursor
     }
   }
 `;

--- a/src/extensions/scratch3_mesh_v2/gql-operations.js
+++ b/src/extensions/scratch3_mesh_v2/gql-operations.js
@@ -50,6 +50,7 @@ const JOIN_GROUP = gql`
       name
       groupId
       domain
+      createdAt
       expiresAt
       heartbeatIntervalSeconds
       useWebSocket
@@ -88,6 +89,7 @@ const RENEW_HEARTBEAT = gql`
     renewHeartbeat(groupId: $groupId, domain: $domain, hostId: $hostId) {
       groupId
       domain
+      createdAt
       expiresAt
       heartbeatIntervalSeconds
     }
@@ -100,6 +102,7 @@ const SEND_MEMBER_HEARTBEAT = gql`
       nodeId
       groupId
       domain
+      createdAt
       expiresAt
       heartbeatIntervalSeconds
     }

--- a/src/extensions/scratch3_mesh_v2/mesh-client.js
+++ b/src/extensions/scratch3_mesh_v2/mesh-client.js
@@ -32,5 +32,6 @@ const getClient = () => client;
 module.exports = {
     createClient,
     getClient,
-    gql
+    gql,
+    GRAPHQL_ENDPOINT
 };

--- a/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -215,9 +215,13 @@ class MeshV2Service {
             try {
                 // Derived from https://xxx.appsync-api.region.amazonaws.com/graphql
                 // to wss://xxx.appsync-realtime-api.region.amazonaws.com/graphql
-                const wsUrl = GRAPHQL_ENDPOINT
-                    .replace('https://', 'wss://')
-                    .replace('appsync-api', 'appsync-realtime-api');
+                // or for custom domains, to wss://api.example.com/graphql/realtime
+                let wsUrl = GRAPHQL_ENDPOINT.replace('https://', 'wss://');
+                if (wsUrl.includes('appsync-api')) {
+                    wsUrl = wsUrl.replace('appsync-api', 'appsync-realtime-api');
+                } else {
+                    wsUrl = wsUrl.replace(/\/graphql$/, '/graphql/realtime');
+                }
 
                 const socket = new WebSocket(wsUrl, 'graphql-ws');
                 const timeout = setTimeout(() => {

--- a/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -917,20 +917,20 @@ class MeshV2Service {
         if (!this.groupId || !this.client || !this.isHost) return;
 
         try {
-                        this.costTracking.mutationCount++;
-                        this.costTracking.heartbeatCount++;
-                        const result = await this.client.mutate({
-                            mutation: RENEW_HEARTBEAT,
-                            variables: {
-                                groupId: this.groupId,
-                                domain: this.domain,
-                                hostId: this.meshId
-                            }
-                        });
-            
-                        this.expiresAt = result.data.renewHeartbeat.expiresAt;
-                        log.info(`Mesh V2: Heartbeat renewed. Expires at: ${this.expiresAt}`);
-            
+            this.costTracking.mutationCount++;
+            this.costTracking.heartbeatCount++;
+            const result = await this.client.mutate({
+                mutation: RENEW_HEARTBEAT,
+                variables: {
+                    groupId: this.groupId,
+                    domain: this.domain,
+                    hostId: this.meshId
+                }
+            });
+
+            this.expiresAt = result.data.renewHeartbeat.expiresAt;
+            log.info(`Mesh V2: Heartbeat renewed. Expires at: ${this.expiresAt}`);
+
             if (result.data.renewHeartbeat.heartbeatIntervalSeconds) {
                 const newInterval = result.data.renewHeartbeat.heartbeatIntervalSeconds;
                 if (newInterval !== this.hostHeartbeatInterval) {

--- a/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -592,7 +592,7 @@ class MeshV2Service {
      * Fetch new events from the server since the last fetch time.
      */
     async pollEvents () {
-        if (!this.groupId || !this.client || this.useWebSocket) return;
+        if (!this.groupId || !this.client || this.useWebSocket || !this.lastFetchTime) return;
 
         try {
             this.costTracking.queryCount++;

--- a/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -612,6 +612,7 @@ class MeshV2Service {
         log.debug(`Mesh V2: pollEvents for group ${this.groupId}. since=${this.lastFetchTime}`);
 
         try {
+            this.costTracking.queryCount++;
             const result = await this.client.query({
                 query: GET_EVENTS_SINCE,
                 variables: {

--- a/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -869,7 +869,7 @@ class MeshV2Service {
                     }
                 });
             } else {
-                await this.client.mutate({
+                const result = await this.client.mutate({
                     mutation: RECORD_EVENTS,
                     variables: {
                         groupId: this.groupId,
@@ -878,6 +878,9 @@ class MeshV2Service {
                         events: events
                     }
                 });
+                if (result.data && result.data.recordEventsByNode && result.data.recordEventsByNode.nextSince) {
+                    this.lastFetchTime = result.data.recordEventsByNode.nextSince;
+                }
             }
         } catch (error) {
             log.error(`Mesh V2: Failed to fire batch events: ${error}`);

--- a/src/extensions/scratch3_mesh_v2/utils.js
+++ b/src/extensions/scratch3_mesh_v2/utils.js
@@ -53,10 +53,20 @@ const saveDomainToLocalStorage = domain => {
 /* istanbul ignore next */
 const getDomain = () => getDomainFromUrl() || getDomainFromLocalStorage();
 
+/* istanbul ignore next */
+const getForcePollingFromUrl = () => {
+    /* istanbul ignore next */
+    if (typeof window === 'undefined') return false;
+    const urlParams = new URLSearchParams(window.location.search);
+    const polling = urlParams.get('mesh_polling');
+    return !!polling && polling !== '0' && polling !== 'false';
+};
+
 module.exports = {
     getDomainFromUrl,
     getDomainFromLocalStorage,
     saveDomainToLocalStorage,
     getDomain,
-    validateDomain
+    validateDomain,
+    getForcePollingFromUrl
 };

--- a/test/unit/extension_mesh_v2_service.js
+++ b/test/unit/extension_mesh_v2_service.js
@@ -39,24 +39,20 @@ test('MeshV2Service Cost Tracking', t => {
                     id: 'g1',
                     name: 'G1',
                     domain: 'd1',
-                    createdAt: '2026-01-11T10:00:00Z',
                     expiresAt: '2099-01-01T00:00:00Z',
                     heartbeatIntervalSeconds: 60
                 },
                 joinGroup: {
                     id: 'n1',
                     domain: 'd1',
-                    createdAt: '2026-01-11T10:00:00Z',
                     expiresAt: '2099-01-01T00:00:00Z',
                     heartbeatIntervalSeconds: 120
                 },
                 renewHeartbeat: {
-                    createdAt: '2026-01-11T10:00:00Z',
                     expiresAt: '2099-01-01T00:00:00Z',
                     heartbeatIntervalSeconds: 60
                 },
                 sendMemberHeartbeat: {
-                    createdAt: '2026-01-11T10:00:00Z',
                     expiresAt: '2099-01-01T00:00:00Z',
                     heartbeatIntervalSeconds: 120
                 }

--- a/test/unit/extension_mesh_v2_service.js
+++ b/test/unit/extension_mesh_v2_service.js
@@ -39,20 +39,24 @@ test('MeshV2Service Cost Tracking', t => {
                     id: 'g1',
                     name: 'G1',
                     domain: 'd1',
+                    createdAt: '2026-01-11T10:00:00Z',
                     expiresAt: '2099-01-01T00:00:00Z',
                     heartbeatIntervalSeconds: 60
                 },
                 joinGroup: {
                     id: 'n1',
                     domain: 'd1',
+                    createdAt: '2026-01-11T10:00:00Z',
                     expiresAt: '2099-01-01T00:00:00Z',
                     heartbeatIntervalSeconds: 120
                 },
                 renewHeartbeat: {
+                    createdAt: '2026-01-11T10:00:00Z',
                     expiresAt: '2099-01-01T00:00:00Z',
                     heartbeatIntervalSeconds: 60
                 },
                 sendMemberHeartbeat: {
+                    createdAt: '2026-01-11T10:00:00Z',
                     expiresAt: '2099-01-01T00:00:00Z',
                     heartbeatIntervalSeconds: 120
                 }

--- a/test/unit/mesh_service_v2_polling.js
+++ b/test/unit/mesh_service_v2_polling.js
@@ -182,9 +182,7 @@ test('MeshV2Service Polling', t => {
         ];
 
         service.client = {
-            query: () => {
-                return Promise.resolve({data: {getEventsSince: events}});
-            }
+            query: () => Promise.resolve({data: {getEventsSince: events}})
         };
 
         await service.pollEvents();

--- a/test/unit/mesh_service_v2_polling.js
+++ b/test/unit/mesh_service_v2_polling.js
@@ -1,0 +1,170 @@
+const test = require('tap').test;
+const minilog = require('minilog');
+// Suppress debug and info logs during tests
+minilog.suggest.deny('vm', 'debug');
+minilog.suggest.deny('vm', 'info');
+
+const MeshV2Service = require('../../src/extensions/scratch3_mesh_v2/mesh-service');
+const {GET_EVENTS_SINCE, RECORD_EVENTS} = require('../../src/extensions/scratch3_mesh_v2/gql-operations');
+
+const createMockBlocks = () => ({
+    runtime: {
+        sequencer: {},
+        emit: () => {},
+        on: () => {},
+        off: () => {}
+    },
+    opcodeFunctions: {
+        event_broadcast: () => {}
+    }
+});
+
+test('MeshV2Service Polling', t => {
+    t.test('pollEvents fetches and handles events', async st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.groupId = 'group1';
+        service.useWebSocket = false;
+        service.lastFetchTime = 'T1';
+
+        const events = [
+            {
+                name: 'e1',
+                firedByNodeId: 'node2',
+                groupId: 'group1',
+                domain: 'domain1',
+                payload: 'p1',
+                timestamp: 'T2',
+                cursor: 'C2'
+            },
+            {
+                name: 'e2',
+                firedByNodeId: 'node2',
+                groupId: 'group1',
+                domain: 'domain1',
+                payload: 'p2',
+                timestamp: 'T3',
+                cursor: 'C3'
+            }
+        ];
+
+        service.client = {
+            query: options => {
+                st.equal(options.query, GET_EVENTS_SINCE);
+                st.equal(options.variables.since, 'T1');
+                return Promise.resolve({
+                    data: {
+                        getEventsSince: events
+                    }
+                });
+            }
+        };
+
+        // Spy on handleBatchEvent
+        let handledBatch = null;
+        service.handleBatchEvent = batch => {
+            handledBatch = batch;
+        };
+
+        await service.pollEvents();
+
+        st.ok(handledBatch);
+        st.equal(handledBatch.events.length, 2);
+        st.equal(handledBatch.events[0].name, 'e1');
+        st.equal(service.lastFetchTime, 'C3');
+
+        st.end();
+    });
+
+    t.test('fireEventsBatch uses RECORD_EVENTS when useWebSocket is false', async st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.groupId = 'group1';
+        service.useWebSocket = false;
+        service.lastFetchTime = null;
+
+        const events = [{eventName: 'e1', payload: 'p1', firedAt: 't1'}];
+
+        service.client = {
+            mutate: options => {
+                st.equal(options.mutation, RECORD_EVENTS);
+                return Promise.resolve({
+                    data: {
+                        recordEventsByNode: {
+                            nextSince: 'T_NEW'
+                        }
+                    }
+                });
+            }
+        };
+
+        await service.fireEventsBatch(events);
+
+        st.equal(service.lastFetchTime, 'T_NEW');
+
+        st.end();
+    });
+
+    t.test('startPolling sets up interval', st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.groupId = 'group1';
+        service.useWebSocket = false;
+        service.pollingIntervalSeconds = 0.01; // 10ms
+
+        let pollCount = 0;
+        service.pollEvents = () => {
+            pollCount++;
+        };
+
+        service.startPolling();
+        st.ok(service.pollingTimer);
+
+        setTimeout(() => {
+            service.stopPolling();
+            st.ok(pollCount > 0);
+            st.equal(service.pollingTimer, null);
+            st.end();
+        }, 50);
+    });
+
+    t.test('testWebSocket success', async st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+
+        // Mock WebSocket
+        global.WebSocket = class {
+            constructor () {
+                setTimeout(() => this.onopen(), 10);
+            }
+            close () {}
+        };
+
+        const result = await service.testWebSocket();
+        st.equal(result, true);
+
+        delete global.WebSocket;
+        st.end();
+    });
+
+    t.test('testWebSocket failure', async st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+
+        // Mock WebSocket
+        global.WebSocket = class {
+            constructor () {
+                setTimeout(() => this.onerror(new Error('fail')), 10);
+            }
+            close () {}
+        };
+
+        const result = await service.testWebSocket();
+        st.equal(result, false);
+
+        delete global.WebSocket;
+        st.end();
+    });
+
+    t.end();
+});

--- a/test/unit/mesh_service_v2_polling.js
+++ b/test/unit/mesh_service_v2_polling.js
@@ -60,17 +60,10 @@ test('MeshV2Service Polling', t => {
             }
         };
 
-        // Spy on handleBatchEvent
-        let handledBatch = null;
-        service.handleBatchEvent = batch => {
-            handledBatch = batch;
-        };
-
         await service.pollEvents();
 
-        st.ok(handledBatch);
-        st.equal(handledBatch.events.length, 2);
-        st.equal(handledBatch.events[0].name, 'e1');
+        st.equal(service.pendingBroadcasts.length, 2);
+        st.equal(service.pendingBroadcasts[0].event.name, 'e1');
         st.equal(service.lastFetchTime, 'C3');
 
         st.end();


### PR DESCRIPTION
## Summary

Client-side implementation of polling-based event notification fallback for Mesh v2. Adds WebSocket connection testing and automatic protocol switching to support environments where WebSocket connections are blocked.

## Implementation Details

### WebSocket Connection Test

Added `testWebSocket()` method to detect WebSocket availability:

```javascript
testWebSocket() {
  return new Promise(resolve => {
    try {
      const wsUrl = GRAPHQL_ENDPOINT
        .replace('https://', 'wss://')
        .replace('appsync-api', 'appsync-realtime-api');

      const socket = new WebSocket(wsUrl, 'graphql-ws');
      const timeout = setTimeout(() => {
        socket.close();
        resolve(false);
      }, 3000);

      socket.onopen = () => {
        clearTimeout(timeout);
        socket.close();
        resolve(true);
      };

      socket.onerror = () => {
        clearTimeout(timeout);
        resolve(false);
      };
    } catch (error) {
      resolve(false);
    }
  });
}
```

### Protocol Selection

#### Host (Group Creation)

1. Tests WebSocket connectivity using `testWebSocket()`
2. Sets `useWebSocket` flag based on test result
3. Sends flag to server via `createGroup` mutation
4. Starts subscription or polling based on flag

#### Member (Group Join)

1. Receives `useWebSocket` flag from `joinGroup` response
2. Starts subscription or polling based on flag

### Polling Implementation

#### Start Polling

```javascript
startPolling() {
  this.stopPolling();
  if (!this.groupId) return;

  log.info(`Mesh V2: Starting event polling (Interval: ${this.pollingIntervalSeconds}s)`);

  if (!this.lastFetchTime) {
    this.lastFetchTime = new Date().toISOString();
  }

  this.pollingTimer = setInterval(() => {
    this.pollEvents();
  }, this.pollingIntervalSeconds * 1000);
}
```

#### Poll Events

```javascript
async pollEvents() {
  if (!this.groupId || !this.client || this.useWebSocket) return;

  try {
    const result = await this.client.query({
      query: GET_EVENTS_SINCE,
      variables: {
        groupId: this.groupId,
        domain: this.domain,
        since: this.lastFetchTime
      },
      fetchPolicy: 'network-only'
    });

    const events = result.data.getEventsSince;
    if (events && events.length > 0) {
      log.info(`Mesh V2: Polled ${events.length} events`);

      const batchEvent = {
        firedByNodeId: 'polling-server',
        events: events.map(e => ({ /* ... */ }))
      };
      this.handleBatchEvent(batchEvent);

      // Update cursor
      this.lastFetchTime = events[events.length - 1].cursor;
    }
  } catch (error) {
    log.error(`Mesh V2: Event polling failed: ${error}`);
    const reason = this.shouldDisconnectOnError(error);
    if (reason) {
      this.cleanupAndDisconnect(reason);
    }
  }
}
```

### Event Transmission Protocol Switching

```javascript
if (this.useWebSocket) {
  // Protocol A: WebSocket
  await this.client.mutate({
    mutation: FIRE_EVENTS,
    variables: { /* ... */ }
  });
} else {
  // Protocol B: Polling
  const result = await this.client.mutate({
    mutation: RECORD_EVENTS,
    variables: { /* ... */ }
  });

  // Update lastFetchTime if null
  if (!this.lastFetchTime) {
    this.lastFetchTime = result.data.recordEventsByNode.nextSince;
  }
}
```

### Cursor Management

- `lastFetchTime`: Stores last cursor (or initial ISO timestamp)
- Updated to `Event.cursor` after each polling
- Used as `since` parameter in next `getEventsSince` call

### GraphQL Operations

Added new operations to `gql-operations.js`:

- `RECORD_EVENTS`: Mutation for recording events (polling)
- `GET_EVENTS_SINCE`: Query for retrieving events (polling)

## Testing

### Unit Tests

**New test file**: `test/unit/mesh_service_v2_polling.js`

- `pollEvents` fetches and handles events correctly
- `fireEventsBatch` uses `RECORD_EVENTS` when `useWebSocket` is false
- Cursor-based pagination works correctly
- `lastFetchTime` is updated with cursor value

### Test Coverage

- WebSocket test scenarios
- Protocol switching (host and member)
- Polling start/stop
- Event polling and processing
- Cursor management

## Configuration

### Default Values

- Polling interval: 2 seconds (from server `pollingIntervalSeconds`)
- WebSocket test timeout: 3 seconds

### Cost Optimization

- **WebSocket Priority**: Uses WebSocket when available (lower cost)
- **Polling Fallback**: Only uses polling when WebSocket is unavailable
- **Cursor-based**: Efficient pagination with cursor

## Breaking Changes

None. This is a backward-compatible addition.

## Related

- Parent PR: smalruby/smalruby3-develop#15
- Related Issue: smalruby/smalruby3-develop#14
- Server PR: smalruby/mesh-v2#40

🤖 Generated with [Claude Code](https://claude.ai/code)
