### PR TITLE
fix: improve 'moved' gesture event behavior in MicrobitMore

### DIFF
--- a/src/extensions/microbitMore/index.js
+++ b/src/extensions/microbitMore/index.js
@@ -2880,42 +2880,22 @@ class MbitMoreBlocks {
         const gestureName = args.GESTURE;
         if (gestureName === 'MOVED') {
             const now = Date.now();
-            const perfNow = performance.now();
             const cooldownTime = this.runtime.currentStepTime * 5;
-            const diff = this.lastMovedEventTime === null ? Infinity : (now - this.lastMovedEventTime);
-            const inCooldown = diff < cooldownTime;
+            if (this.lastMovedEventTime !== null) {
+                if ((now - this.lastMovedEventTime) < cooldownTime) {
+                    return false;
+                }
+            }
 
-            let triggerEvent = null;
             const eventOccurred = Object.entries(this._peripheral.gestureEvents).some(([name, timestamp]) => {
-                let isChanged = false;
                 if (this.prevGestureEvents[name]) {
-                    isChanged = timestamp !== this.prevGestureEvents[name];
-                } else {
-                    isChanged = true;
+                    return timestamp !== this.prevGestureEvents[name];
                 }
-                if (isChanged) {
-                    triggerEvent = {name, timestamp, prev: this.prevGestureEvents[name]};
-                }
-                return isChanged;
+                return true;
             });
-
-            if (eventOccurred || diff >= cooldownTime) {
-                const logMsg = `[DEBUG MOVED] Time: ${perfNow.toFixed(3)}ms (Date: ${now}), ` +
-                            `Diff: ${diff}ms, Cooldown: ${cooldownTime}ms, InCooldown: ${inCooldown}`;
-                console.log(logMsg);
-                if (eventOccurred) {
-                    console.log(`[DEBUG MOVED] Triggered by: ${triggerEvent.name}, ` +
-                                `Timestamp: ${triggerEvent.timestamp}, Prev: ${triggerEvent.prev}`);
-                }
-            }
-
-            if (inCooldown) {
-                return false;
-            }
 
             if (eventOccurred) {
                 this.lastMovedEventTime = now;
-                console.log(`[DEBUG MOVED] Event FIRED at ${performance.now().toFixed(3)}ms`);
             }
 
             return eventOccurred;

--- a/src/extensions/microbitMore/index.js
+++ b/src/extensions/microbitMore/index.js
@@ -2899,7 +2899,7 @@ class MbitMoreBlocks {
         if (gestureName === 'MOVED') {
             const now = Date.now();
             const stepTime = this.runtime.currentStepTime;
-            const gapThreshold = stepTime * 10; // 10フレームの空白
+            const gapThreshold = stepTime * 5; // 5フレームの空白
             const timeoutThreshold = stepTime * 30; // 30フレームで強制発火
 
             const changedGestures = [];

--- a/src/extensions/microbitMore/index.js
+++ b/src/extensions/microbitMore/index.js
@@ -2899,7 +2899,7 @@ class MbitMoreBlocks {
         if (gestureName === 'MOVED') {
             const now = Date.now();
             const stepTime = this.runtime.currentStepTime;
-            const gapThreshold = stepTime * 5; // 5フレームの空白
+            const gapThreshold = stepTime * 10; // 10フレームの空白
             const timeoutThreshold = stepTime * 30; // 30フレームで強制発火
 
             const changedGestures = [];

--- a/src/extensions/microbitMore/index.js
+++ b/src/extensions/microbitMore/index.js
@@ -2876,7 +2876,6 @@ class MbitMoreBlocks {
      * Update the last occured time of all gesture events.
      */
     updatePrevGestureEvents () {
-        console.log(`[DEBUG MOVED] updatePrevGestureEvents at ${performance.now().toFixed(3)}ms`);
         this.prevGestureEvents = {};
         Object.entries(this._peripheral.gestureEvents).forEach(([gestureName, timestamp]) => {
             this.prevGestureEvents[gestureName] = timestamp;
@@ -2899,7 +2898,6 @@ class MbitMoreBlocks {
         const gestureName = args.GESTURE;
         if (gestureName === 'MOVED') {
             const now = Date.now();
-            const perfNow = performance.now();
             const stepTime = this.runtime.currentStepTime;
             const gapThreshold = stepTime * 5; // 5フレームの空白
             const timeoutThreshold = stepTime * 30; // 30フレームで強制発火
@@ -2924,14 +2922,10 @@ class MbitMoreBlocks {
             const timeSinceLastOccurred = this.lastGestureOccurredTime === null ?
                 Infinity : (now - this.lastGestureOccurredTime);
             if (timeSinceLastOccurred >= gapThreshold) {
-                if (this.isWaitingForGap) {
-                    console.log(`[DEBUG MOVED] Gap detected (${timeSinceLastOccurred.toFixed(1)}ms). Resetting.`);
-                }
                 this.isWaitingForGap = false;
             }
 
             let shouldFire = false;
-            let fireReason = '';
 
             if (eventDetected) {
                 if (this.isWaitingForGap) {
@@ -2940,26 +2934,15 @@ class MbitMoreBlocks {
                         Infinity : (now - this.lastMovedEventTime);
                     if (timeSinceLastFired >= timeoutThreshold) {
                         shouldFire = true;
-                        fireReason = `Continuous movement timeout (${timeSinceLastFired.toFixed(1)}ms)`;
                     }
                 } else {
                     shouldFire = true;
-                    fireReason = 'Movement started after gap';
-                }
-            }
-
-            if (eventDetected || shouldFire || this.isWaitingForGap) {
-                console.log(`[DEBUG MOVED] Time: ${perfNow.toFixed(3)}ms, Detected: ${eventDetected}, ` +
-                            `Waiting: ${this.isWaitingForGap}, ShouldFire: ${shouldFire}, Reason: ${fireReason}`);
-                if (eventDetected) {
-                    console.log(`[DEBUG MOVED] Changes: [${changedGestures.join(', ')}]`);
                 }
             }
 
             if (shouldFire) {
                 this.lastMovedEventTime = now;
                 this.isWaitingForGap = true;
-                console.log(`[DEBUG MOVED] *** FIRED *** at ${perfNow.toFixed(3)}ms`);
             }
 
             return shouldFire;


### PR DESCRIPTION
## Summary
This PR improves the 'moved' gesture event behavior in the MicrobitMore extension.

## Changes
- **Cooldown for 'moved' event**: Added a cooldown mechanism (approximately 165ms) to prevent the event from firing too frequently when the micro:bit is moved.
- **Menu order**: Moved the 'moved' gesture to the top of the gestures menu for better accessibility.
- **Default value**: Changed the default gesture for the 'when gesture' block to 'moved'.

## Implementation Details
- Initialized  in  constructor.
- Updated  to check the elapsed time since the last 'moved' event.
- Reordered .
- Updated the block definition in .

Part of smalruby/smalruby3-develop#20